### PR TITLE
(#104) Make an option to rewrite JPeek's target directory if exists

### DIFF
--- a/src/main/java/org/jpeek/App.java
+++ b/src/main/java/org/jpeek/App.java
@@ -31,7 +31,6 @@ import com.jcabi.xml.XSDDocument;
 import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,14 +124,6 @@ public final class App {
      */
     @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void analyze() throws IOException {
-        if (Files.exists(this.output)) {
-            throw new IllegalStateException(
-                String.format(
-                    "Directory/file already exists: %s",
-                    this.output.normalize().toAbsolutePath()
-                )
-            );
-        }
         final Base base = new DefaultBase(this.input);
         final XML skeleton = new Skeleton(base).xml();
         this.save(skeleton.toString(), "skeleton.xml");

--- a/src/main/java/org/jpeek/Main.java
+++ b/src/main/java/org/jpeek/Main.java
@@ -72,7 +72,8 @@ public final class Main {
 
     @Parameter(
         names = "--overwrite",
-        description = "Overwrite the target directory if it exists"
+        // @checkstyle LineLength (1 line)
+        description = "Overwrite the target directory if it exists (otherwise an error is raised)"
     )
     private boolean overwrite;
 
@@ -100,6 +101,10 @@ public final class Main {
     /**
      * Run it.
      * @throws IOException If fails
+     * @todo #104:30min The logic for overwriting the target directory is very
+     *  procedural and needs to be refactored. Suggestion: 'target' should be
+     *  its own animated object where the logic is triggered in its 'toPath'
+     *  method.
      */
     private void run() throws IOException {
         if (this.target.exists()) {

--- a/src/test/java/org/jpeek/MainTest.java
+++ b/src/test/java/org/jpeek/MainTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class MainTest {
 
     @Test
@@ -57,4 +58,27 @@ public final class MainTest {
         Main.main("hello");
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void crashesIfNoOverwriteAndTargetExists() throws IOException {
+        final Path target = Files.createTempDirectory("");
+        Main.main(
+            "--sources", Paths.get(".").toString(),
+            "--target", target.toString()
+        );
+    }
+
+    @Test
+    public void createsXmlReportsIfOverwriteAndTargetExists()
+        throws IOException {
+        final Path target = Files.createTempDirectory("");
+        Main.main(
+            "--sources", Paths.get(".").toString(),
+            "--target", target.toString(),
+            "--overwrite"
+        );
+        MatcherAssert.assertThat(
+            Files.exists(target.resolve("LCOM.xml")),
+            Matchers.equalTo(true)
+        );
+    }
 }


### PR DESCRIPTION
as per #104 

Note:
I moved the `Files.exist(target)` check from `App.analyze()` to `Main.run()` because I didn't want to pollute `App` with this miscellaneous parameter and just wanted to let `App.analyze()` to focus on doing the *analysis*.