### PR TITLE
(#125) Enable Bar test for LCOM5

### DIFF
--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -39,9 +39,6 @@ import org.junit.runners.Parameterized;
 // @todo #18:30min Impediment: #103 must be fixed before LCOM5 is tested
 //  against: NoMethods, OneVoidMethodWithoutParams, WithoutAttributes,
 //  OneMethodCreatesLambda. The LCOM5 value for these will be "NaN".
-// @todo #18:30min Impediment: test for LCOM5 with "Bar" is not working
-//  because the generated skeleton.xml is not including all attributes
-//  being used by a method. See #114.
 // @todo #93:30min NHD needs to be tested against the following after #103 is
 //  fixed: NoMethods, OneVoidMethodWithoutParams, WithoutAttributes,
 //  OneMethodCreatesLambda. NHD score for all these is "NaN".
@@ -120,6 +117,7 @@ public final class MetricsTest {
             new Object[] {"WithoutAttributes", "MMAC", 0.0d},
             new Object[] {"OneMethodCreatesLambda", "MMAC", 0.0d},
             new Object[] {"Foo", "LCOM5", 0.5d},
+            new Object[] {"Bar", "LCOM5", 0.8125d},
             new Object[] {"MethodsWithDiffParamTypes", "LCOM5", 0.6667d},
             new Object[] {"OverloadMethods", "LCOM5", 0.25d},
             new Object[] {"TwoCommonAttributes", "LCOM5", 1.0d},


### PR DESCRIPTION
Solution for #125

Given that

> The values for LCOM5 are defined in the real interval [0, 1] where '0' describes "perfect cohesion" and '1' describes "no cohesion".

the value `0.8125d` looks believable. Before fixing #114 it was over `1.0d` which contradicts the LCOM5 definition.