### PR TITLE
(#119) LCC and Transitive Closures

### DIFF
--- a/src/main/resources/org/jpeek/metrics/LCC.xsl
+++ b/src/main/resources/org/jpeek/metrics/LCC.xsl
@@ -58,10 +58,13 @@ SOFTWARE.
       </xsl:for-each>
     </xsl:variable>
     <!--
-    @todo #9:30min `indirectly-related-pairs` are pairs of methods, which are through other directly connected methods.
-     https://pdfs.semanticscholar.org/672e/de6e3e600eafd84036a0b983b88e481ac626.pdf
-     Right now it is stubbed because information about method-method communication is yet to be provided in skeleton.xml
-     (issue #106).
+    @todo #119:30min `indirectly-related-pairs` are pairs of methods, which are connected through `directly-related-pairs`.
+     See section 3.1 of https://pdfs.semanticscholar.org/672e/de6e3e600eafd84036a0b983b88e481ac626.pdf
+     The key sentence is "The indirect connection relation is the **transitive closure** of direct connection relation".
+     See https://en.wikipedia.org/wiki/Transitive_closure for more info on what is a Transitive Closure.
+     We need to apply a Transitive Closure Algorithm on a graph of `directly-related-pairs`.
+     A simpliest Transitive Closure algorithms has O(V³) time complexity and involves a mutable V×V table (V is amount of vertices).
+     See https://www.geeksforgeeks.org/transitive-closure-of-a-graph/ for an example.
     -->
     <!--<xsl:variable name="indirectly-related-pairs">
     </xsl:variable>


### PR DESCRIPTION
As per #119

The assumption made in #119 is absolutly incorrect. Changes made in #106 are not needed to calculate `indirectly-related-pairs`. See section 3.1 of https://pdfs.semanticscholar.org/672e/de6e3e600eafd84036a0b983b88e481ac626.pdf. The key sentence is

> The indirect connection relation is the **transitive closure** of direct connection relation

See https://en.wikipedia.org/wiki/Transitive_closure for more info on what is a Transitive Closure. Basically, if you have a graph of relationships define by adjacency pairs:

```
graph:
  a - b
  b - c
  b - d
  c - e
```

that looks like this:

```
     c--e
    /
a--b
    \
     d
```

A transitive closure of that graph is simply an extention of adjacency pairs list with transitively reachable verticies:

```
graph:
  // original pairs
  a - b
  b - c
  b - d
  c - e
  // "transitive extension"
  a - c
  a - e
  a - d
  b - e
```

Calculating `indirectly-related-pairs` has nothing to do with the methods calling each other (see #106). `indirectly-related-pairs` must be calculated in terms of `directly-related-pairs`. We need to apply a Transitive Closure Algorithm on a graph of `directly-related-pairs`.

A simpliest Transitive Closure algorithms has O(V³) time complexity and involves a mutable V×V table (V is amount of vertices). See https://www.geeksforgeeks.org/transitive-closure-of-a-graph/ for an example. Researching how to fit that into a declartive nature of XSLT looks like outside of the scope of 30 minutes for me.