### PR TITLE
(#124) LCOM5 tests

### DIFF
--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -125,7 +125,7 @@ public final class MetricsTest {
             new Object[] {"NoMethods", "LCOM5", Double.NaN},
             new Object[] {"WithoutAttributes", "LCOM5", Double.NaN},
             new Object[] {"OneVoidMethodWithoutParams", "LCOM5", 1.0d},
-            new Object[] {"OneMethodCreatesLambda", "LCOM5", Double.NaN},
+            new Object[] {"OneMethodCreatesLambda", "LCOM5", 1.5d},
             new Object[] {"Bar", "NHD", 0.4d},
             new Object[] {"Foo", "NHD", 0.3333d},
             new Object[] {"MethodsWithDiffParamTypes", "NHD", 0.7143d},

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -36,9 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-// @todo #18:30min Impediment: #103 must be fixed before LCOM5 is tested
-//  against: NoMethods, OneVoidMethodWithoutParams, WithoutAttributes,
-//  OneMethodCreatesLambda. The LCOM5 value for these will be "NaN".
 // @todo #93:30min NHD needs to be tested against the following after #103 is
 //  fixed: NoMethods, OneVoidMethodWithoutParams, WithoutAttributes,
 //  OneMethodCreatesLambda. NHD score for all these is "NaN".
@@ -125,6 +122,10 @@ public final class MetricsTest {
             new Object[] {"MethodsWithDiffParamTypes", "LCOM5", 0.6667d},
             new Object[] {"OverloadMethods", "LCOM5", 0.25d},
             new Object[] {"TwoCommonAttributes", "LCOM5", 1.0d},
+            new Object[] {"NoMethods", "LCOM5", Double.NaN},
+            new Object[] {"WithoutAttributes", "LCOM5", Double.NaN},
+            new Object[] {"OneVoidMethodWithoutParams", "LCOM5", 1.0d},
+            new Object[] {"OneMethodCreatesLambda", "LCOM5", Double.NaN},
             new Object[] {"Bar", "NHD", 0.4d},
             new Object[] {"Foo", "NHD", 0.3333d},
             new Object[] {"MethodsWithDiffParamTypes", "NHD", 0.7143d},


### PR DESCRIPTION
As per #124 

LCOM5 for [OneVoidMethodWithoutParams][OneVoidMethodWithoutParams.java] will not be `NaN`. According to [LCOM5.xsl][LCOM5.xsl] the value will be `NaN` only when the class has 1 method. The Skeleton treats the constructor of the class as a method, so [OneVoidMethodWithoutParams][OneVoidMethodWithoutParams.java] has in fact two methods.

**UPD.** Same goes for [OneMethodCreatesLambda][OneMethodCreatesLambda.java] for the same reason

[LCOM5.xsl]: https://github.com/yegor256/jpeek/blob/bdacc739c3660720f3bbb2a1fbf23f236f117030/src/main/resources/org/jpeek/metrics/LCOM5.xsl
[OneVoidMethodWithoutParams.java]: https://github.com/yegor256/jpeek/blob/bdacc739c3660720f3bbb2a1fbf23f236f117030/src/test/resources/org/jpeek/samples/OneVoidMethodWithoutParams.java
[OneMethodCreatesLambda.java]: https://github.com/yegor256/jpeek/blob/bdacc739c3660720f3bbb2a1fbf23f236f117030/src/test/resources/org/jpeek/samples/OneMethodCreatesLambda.java