### PR TITLE
(#138) Added documentation in README for known limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Thus, all calculations happen inside the XSLT files. We decided to implement
 it this way after a less successful attempt to do it all in Java. It seems
 that XSL is much more suitable for manipulations with data than Java.
 
+## Known Limitations
+
+* The java compiler is known to inline constant variables as per [JLS 13.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1). This may affect the results obtained by some metrics when a method of a class being analyzed accesses a constant variable (basically the access to the constant will not be included in the calculations).
+
 ## How to contribute?
 
 Just fork, make changes, run `mvn clean install -Pqulice` and submit

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ that XSL is much more suitable for manipulations with data than Java.
 
 ## Known Limitations
 
-* The java compiler is known to inline constant variables as per [JLS 13.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1). This may affect the results obtained by some metrics when a method of a class being analyzed accesses a constant variable (basically the access to the constant will not be included in the calculations).
+* The java compiler is known to inline constant variables as per [JLS 13.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1). This affects the results calculated by some metrics when a method accesses `final` attributes (the access to the constants are not be included in the calculation).
 
 ## How to contribute?
 

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -52,9 +52,6 @@ import org.junit.runners.Parameterized;
 // @todo #68:30min SCOM has an impediment on issue #114: cannot currently
 //  be tested against "Bar" because the skeleton is incorrectly excluding
 //  some attributes from some methods that are using them.
-// @todo #92:30min Impediment: test for LCOM2/3 with "Bar" is not working
-//  because the generated skeleton.xml is not including all attributes
-//  being used by a method. See #114.
 // @todo #92:30min Impediment: test for LCOM3 with "OneMethodCreatesLambda"
 //  does not work because the skeleton.xml creates a <method> for the
 //  lambda with no way to discriminate it from regular methods.


### PR DESCRIPTION
As per #138:

Turns out that we *cannot* test LCOM2/3 against `Bar` because the compiler optimizes the bytecode by inlining the value of `Bar.NAME` inside the `Bar.getKey()` method. Therefore, the README was updated with a new section **Known Limitations** documenting this shortcoming.

For further details please see comments starting [here](https://github.com/yegor256/jpeek/issues/138#issuecomment-366548476)