### PR TITLE
#142: Implemented calculation of SCOM_minK for the SCOM metric

### DIFF
--- a/src/main/resources/org/jpeek/metrics/SCOM.xsl
+++ b/src/main/resources/org/jpeek/metrics/SCOM.xsl
@@ -147,6 +147,11 @@ SOFTWARE.
         <var id="a">
           <xsl:value-of select="$a"/>
         </var>
+        <!--
+        @todo #142:30min SCOM: implement tests for SCOM_minK after #222 is fixed.
+         Currently, the test harness in MetricsTest does not provide a way to
+         test values of vars.
+        -->
         <var id="SCOM_minK">
           <xsl:value-of select="$SCOM_minK"/>
         </var>

--- a/src/main/resources/org/jpeek/metrics/SCOM.xsl
+++ b/src/main/resources/org/jpeek/metrics/SCOM.xsl
@@ -57,6 +57,18 @@ SOFTWARE.
     <xsl:variable name="m" select="count($methods)"/>
     <xsl:variable name="attributes" select="attributes/attribute/text()"/>
     <xsl:variable name="a" select="count($attributes)"/>
+    <xsl:variable name="SCOM_minK">
+      <xsl:choose>
+        <xsl:when test="$m = 0 or $m = 1 or $a = 0">
+          <xsl:text>NaN</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:variable name="x" select="($m - 1) div $a"/>
+          <xsl:variable name="S" select="0.5 * (1 + floor($x)) * (($x - floor($x)) + $m - 1)"/>
+          <xsl:value-of select="$S * (2 div ($m * ($m - 1) * $a))"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:variable name="pairs">
       <xsl:for-each select="$methods">
         <xsl:variable name="method" select="."/>
@@ -125,11 +137,6 @@ SOFTWARE.
         </xsl:choose>
       </xsl:attribute>
       <xsl:apply-templates select="@*"/>
-      <!--
-        @todo #68:30min Calculate SCOM_min as per page 86 of the paper (I don't
-         know what the "int" function means). This value can be used as a guide
-         to determine whether a class needs to be split into several classes.
-      -->
       <vars>
         <var id="m">
           <xsl:value-of select="$m"/>
@@ -139,6 +146,9 @@ SOFTWARE.
         </var>
         <var id="a">
           <xsl:value-of select="$a"/>
+        </var>
+        <var id="SCOM_minK">
+          <xsl:value-of select="$SCOM_minK"/>
         </var>
       </vars>
     </xsl:copy>


### PR DESCRIPTION
for #142:

This PR adds the calculation of the `SCOM_minK` value as part of the `SCOM` metric. As per the [paper](https://github.com/yegor256/jpeek/blob/master/papers/fernandez06.pdf) on page 86:

> A class with SCOM < SCOMminK does not satisfy the induction premise. Consequently, we can claim that it has at least two clusters and it must be subdivided into smaller, more cohesive classes.

This PR also leaves a puzzle for implementing tests on `SCOM_minK` later after #222 is fixed.