### PR TITLE
#148 For CCM, cannot add test case for class Bar

### DIFF
--- a/src/main/java/org/jpeek/App.java
+++ b/src/main/java/org/jpeek/App.java
@@ -68,16 +68,11 @@ import org.xembly.Xembler;
  * @checkstyle MethodLengthCheck (500 lines)
  * @checkstyle JavaNCSSCheck (500 lines)
  *
- * @todo #9:30min LCC metric has impediments (see puzzles in LCC.xml).
- *  Once they are resolved, cover the metric with autotests and add it
- *  to reports list.
- *  (details on how to test the metrics are to be negotiated here - #107)
- *
  * @todo #17:30min MWE metric has impediments (see puzzles in MWE.xml).
  *  Once they are resolved, cover the metric with autotests and add it
  *  to reports list.
  *  (details on how to test the metrics are to be negotiated here - #107)
- */
+*/
 @SuppressWarnings
     (
         {
@@ -125,7 +120,8 @@ public final class App {
                 new MapEntry<>("OCC", true),
                 new MapEntry<>("PCC", true),
                 new MapEntry<>("TCC", true),
-                new MapEntry<>("LCC", true)
+                new MapEntry<>("LCC", true),
+                new MapEntry<>("CCM", true)
             )
         );
     }
@@ -263,6 +259,14 @@ public final class App {
                 new Report(
                     chain.transform(skeleton),
                     "LCC"
+                )
+            );
+        }
+        if (this.params.containsKey("CCM")) {
+            reports.add(
+                new Report(
+                    chain.transform(skeleton),
+                    "CCM"
                 )
             );
         }

--- a/src/main/resources/org/jpeek/metrics/CCM.xsl
+++ b/src/main/resources/org/jpeek/metrics/CCM.xsl
@@ -48,12 +48,6 @@ SOFTWARE.
         <xsl:for-each select="$method/following-sibling::method">
           <xsl:variable name="other" select="."/>
           <!--
-           @todo #66:30min For CCM, the following test cases need to be
-            added after #103 is fixed: NoMethods, WithoutAttributes,
-            OneMethodCreatesLambda, OneVoidMethodWithoutParams. The CCM value
-            for these cases is NaN.
-          -->
-          <!--
            @todo #66:30min For CCM, need to add OR condition to the following
             xsl:if to check whether two methods both call another method in
             common for the same class. The skeleton currently does not produce

--- a/src/main/resources/org/jpeek/metrics/CCM.xsl
+++ b/src/main/resources/org/jpeek/metrics/CCM.xsl
@@ -54,11 +54,6 @@ SOFTWARE.
             for these cases is NaN.
           -->
           <!--
-           @todo #66:30min For CCM, cannot add test case for class Bar because
-            it is blocked by #114. Omission of the 'NAME' <op> for "getKey"
-            messes up calculations. Add test case after #114 is fixed.
-          -->
-          <!--
            @todo #66:30min For CCM, need to add OR condition to the following
             xsl:if to check whether two methods both call another method in
             common for the same class. The skeleton currently does not produce

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -70,9 +70,15 @@ import org.junit.runners.Parameterized;
  *  and hence they were removed. Need to do the math for those tests and then
  *  add them back: SCOM with "Foo", SCOM with "MethodsWithDiffParamTypes",
  *  and SCOM with "OverloadMethods".
+ * @todo #118:30min Add test for LCC with "IndirectlyRelatedPairs" and others.
+ *  In "IndirectlyRelatedPairs" all methods exist in one transitive closure,
+ *  so the result should be {@code 1d}.
+ *  Also, all classes without transitive relations
+ *  should have the same LCC metric as TCC metric.
+ *  Before do it we have to fix puzzles in LCC.xml.
  */
 @RunWith(Parameterized.class)
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveMethodLength"})
 public final class MetricsTest {
 
     @Parameterized.Parameter
@@ -151,6 +157,7 @@ public final class MetricsTest {
             new Object[] {"OverloadMethods", "TCC", 1.0d},
             new Object[] {"TwoCommonAttributes", "TCC", 0.0d},
             new Object[] {"WithoutAttributes", "TCC", 0.0d},
+            new Object[] {"IndirectlyRelatedPairs", "TCC", 0.6667},
             new Object[] {"Foo", "TLCOM", 1.0d},
             new Object[] {"MethodsWithDiffParamTypes", "TLCOM", 15.0d},
             new Object[] {"NoMethods", "TLCOM", 0.0d},
@@ -171,6 +178,10 @@ public final class MetricsTest {
             new Object[] {"OverloadMethods", "LCC", 1.0d},
             new Object[] {"TwoCommonAttributes", "LCC", 0.0d},
             new Object[] {"WithoutAttributes", "LCC", 0.0d},
+            new Object[] {"NoMethods", "CCM", Double.NaN},
+            new Object[] {"WithoutAttributes", "CCM", Double.NaN},
+            new Object[] {"OneMethodCreatesLambda", "CCM", Double.NaN},
+            new Object[] {"OneVoidMethodWithoutParams", "CCM", Double.NaN},
             new Object[] {"Bar", "CCM", 0.125d}
         );
     }

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -170,7 +170,8 @@ public final class MetricsTest {
             new Object[] {"OnlyOneMethodWithParams", "LCC", 0.0d},
             new Object[] {"OverloadMethods", "LCC", 1.0d},
             new Object[] {"TwoCommonAttributes", "LCC", 0.0d},
-            new Object[] {"WithoutAttributes", "LCC", 0.0d}
+            new Object[] {"WithoutAttributes", "LCC", 0.0d},
+            new Object[] {"Bar", "CCM", 0.125d}
         );
     }
 

--- a/src/test/resources/org/jpeek/samples/IndirectlyRelatedPairs.java
+++ b/src/test/resources/org/jpeek/samples/IndirectlyRelatedPairs.java
@@ -1,0 +1,15 @@
+public final class IndirectlyRelatedPairs {
+    int a, b, c, d;
+    public IndirectlyRelatedPairs(final int x) {
+        methodOne(a+d);
+    }
+    public void methodOne(final int x) {
+        methodTwo(a+b);
+    }
+    public void methodTwo(final int x) {
+        methodThree(b+c);
+    }
+    public void methodThree(final int x) {
+        new IndirectlyRelatedPairs(c+d);
+    }
+}


### PR DESCRIPTION
**Issue #148**

For CCM, cannot add test case for class Bar because it is blocked by 114. Omission of the 'NAME' <op> for "getKey" messes up calculations. Add test case after 114 is fixed.