### PR TITLE
#149 For CCM, need to add OR condition to the following xsl

### DIFF
--- a/src/main/resources/org/jpeek/metrics/CCM.xsl
+++ b/src/main/resources/org/jpeek/metrics/CCM.xsl
@@ -52,13 +52,6 @@ SOFTWARE.
             it is blocked by #114. Omission of the 'NAME' <op> for "getKey"
             messes up calculations. Add test case after #114 is fixed.
           -->
-          <!--
-           @todo #66:30min For CCM, need to add OR condition to the following
-            xsl:if to check whether two methods both call another method in
-            common for the same class. The skeleton currently does not produce
-            this information. After this is done, we can add test cases for Foo,
-            OverloadMethods, and TwoCommonAttributes.
-          -->
           <xsl:if test="$method/ops/op/text()[. = $other/ops/op/text()]">
             <edge>
               <method>

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -181,7 +181,11 @@ public final class MetricsTest {
             new Object[] {"NoMethods", "CCM", Double.NaN},
             new Object[] {"WithoutAttributes", "CCM", Double.NaN},
             new Object[] {"OneMethodCreatesLambda", "CCM", Double.NaN},
-            new Object[] {"OneVoidMethodWithoutParams", "CCM", Double.NaN}
+            new Object[] {"OneVoidMethodWithoutParams", "CCM", Double.NaN},
+            new Object[] {"Foo", "CCM", 0.1667d},
+            new Object[] {"OverloadMethods", "CCM", 0.6d},
+            new Object[] {"TwoCommonAttributes", "CCM", Double.NaN},
+            new Object[] {"TwoCommonMethods", "CCM", 0.0238d}
         );
     }
 

--- a/src/test/resources/org/jpeek/samples/TwoCommonMethods.java
+++ b/src/test/resources/org/jpeek/samples/TwoCommonMethods.java
@@ -1,0 +1,23 @@
+public final class TwoCommonMethods {
+
+  public int methodOne(final int i) {
+    return i * 2;
+  }
+
+  public int methodTwo() {
+    return methodOne(2);
+  }
+
+  public int methodThree() {
+    return methodOne(3);
+  }
+
+  public double methodFour(final double d) {
+    return d * 2;
+  }
+
+  public double methodFive() { return methodFour(5); }
+
+  public double methodSix() { return methodFour(6); }
+
+}


### PR DESCRIPTION
**Issue #149**

CCM.xsl:63-67
For CCM, need to add OR condition to the following xsl:if to check whether two methods both call another method in common for the same class. The skeleton currently does not produce this information. After this is done, we can add test cases for Foo, OverloadMethods, and TwoCommonAttributes.
