### PR TITLE
#156: Determining if Skeleton is accessing same class or another class.

### DIFF
--- a/src/test/java/org/jpeek/skeleton/SkeletonTest.java
+++ b/src/test/java/org/jpeek/skeleton/SkeletonTest.java
@@ -27,6 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.jpeek.FakeBase;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -35,6 +36,11 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.23
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @todo #156:30min Skeleton must be upgraded to determine if a field being
+ *  accessed in a method belongs to that class or to another class. The test in
+ *  findFieldWithQualifiedName must be uncommented when this issue is
+ *  resolved. Please see #156 for more detailing in upgrading skeleton
+ *  behavior.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SkeletonTest {
@@ -98,6 +104,27 @@ public final class SkeletonTest {
                 "//class[@id='Bar']/methods/method[@name='setValue']/ops[op ='java.lang.UnsupportedOperationException.<init>']",
                 "//class[@id='Foo']/methods/method[@name='methodOne']/ops[op = 'Foo.methodTwo']",
                 "//class[@id='Foo']/methods/method[@name='methodTwo']/ops[op = 'Foo.methodOne']"
+            )
+        );
+    }
+
+    @Test
+    @Ignore
+    public void findFieldWithQualifiedName() {
+        MatcherAssert.assertThat(
+            XhtmlMatchers.xhtml(
+                new Skeleton(
+                    new FakeBase(
+                        "ClassWithPublicField",
+                        "ClassAccessingPublicField"
+                    )
+                )
+                .xml()
+                .toString()
+            ),
+            XhtmlMatchers.hasXPaths(
+                // @checkstyle LineLength (1 line)
+                "//class[@id='ClassAccessingPublicField']//method[@name='test']/ops/op[@code='put_static' and .='org.jpeek.samples.ClassWithPublicField.NAME']"
             )
         );
     }

--- a/src/test/resources/org/jpeek/samples/ClassAccessingPublicField.java
+++ b/src/test/resources/org/jpeek/samples/ClassAccessingPublicField.java
@@ -1,0 +1,9 @@
+package org.jpeek.samples;
+
+public final class ClassAccessingPublicField {
+    public static String NAME = "hey";
+
+    public void test() {
+        ClassWithPublicField.NAME = "test";
+    }
+}

--- a/src/test/resources/org/jpeek/samples/ClassWithPublicField.java
+++ b/src/test/resources/org/jpeek/samples/ClassWithPublicField.java
@@ -1,0 +1,9 @@
+package org.jpeek.samples;
+
+public class ClassWithPublicField {
+    public static String NAME = "hey";
+
+    public void test() {
+        ClassWithPublicField.NAME = "test";
+    }
+}


### PR DESCRIPTION
For #156:
- created classes `ClassWithPublicField` and `ClassAccessingWithPublicField` to emulate the desired scenario;
- created test in `SkeletonTest` for testing if the `Skeleton` class is behaving like intended;
- left `@todo` in `SkeletonTest` for upgrade existing `Skeleton` implementation.