### PR TITLE
#246: internalization problem in numeric tests fixed

### DIFF
--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Locale;
+
 import org.cactoos.collection.CollectionOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
@@ -222,6 +224,7 @@ public final class MetricsTest {
             ),
             XhtmlMatchers.hasXPaths(
                 String.format(
+                    Locale.US,
                     xpath,
                     this.target, this.value
                 )

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Locale;
-
 import org.cactoos.collection.CollectionOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;


### PR DESCRIPTION
To fix the problem it's enough to specify the US locale in String.format() method inside assertThat()