### PR TITLE
(#225) Added a matrix.xsd reference to matrix.xml

### DIFF
--- a/src/main/java/org/jpeek/Matrix.java
+++ b/src/main/java/org/jpeek/Matrix.java
@@ -96,6 +96,17 @@ final class Matrix implements Iterable<Directive> {
         return new Directives()
             .add("matrix")
             .append(new Header())
+            .append(
+                () -> new Directives()
+                    .attr(
+                        "xmlns:xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance"
+                    )
+                    .attr(
+                        "xsi:noNamespaceSchemaLocation",
+                        "xsd/matrix.xsd"
+                    )
+                    .iterator())
             .add("classes")
             .append(
                 new Joined<Directive>(

--- a/src/main/resources/org/jpeek/xsd/matrix.xsd
+++ b/src/main/resources/org/jpeek/xsd/matrix.xsd
@@ -26,9 +26,6 @@ SOFTWARE.
 @todo #134:30min Matrix.xsd: add `xsd:documentation` tags as per issue #134. We need to
  document the schemas in src/resources/org/jpeek/xsd so that the semantics of
  the generated XML documents is transparent for maintainers.
-@todo #135:30min Matrix.xsd: add a reference to this schema from the generated
- matrix.xml. Schemas from src/resources/org/jpeek/xsd must be referenced in
- generated XMLs.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="matrix">

--- a/src/test/java/org/jpeek/MatrixTest.java
+++ b/src/test/java/org/jpeek/MatrixTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -40,17 +41,38 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class MatrixTest {
+    /**
+     * Xml file content as a string.
+     */
+    private String xml;
 
-    @Test
-    public void createsMatrixXml() throws IOException {
+    @Before
+    public void setUp() throws IOException {
         final Path output = Files.createTempDirectory("").resolve("x2");
         final Path input = Paths.get(".");
         new App(input, output).analyze();
+        this.xml = new TextOf(output.resolve("matrix.xml")).asString();
+    }
+
+    @Test
+    public void createsMatrixXml() {
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
-                new TextOf(output.resolve("matrix.xml")).asString()
+                this.xml
             ),
             XhtmlMatchers.hasXPaths("/matrix/classes")
+        );
+    }
+
+    @Test
+    public void xmlHasSchema() {
+        MatcherAssert.assertThat(
+            XhtmlMatchers.xhtml(
+                this.xml
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/matrix[@xsi:noNamespaceSchemaLocation='xsd/matrix.xsd']"
+            )
         );
     }
 


### PR DESCRIPTION
This PR (#225).
- adds a new test case xmlHasSchema that checks whether the matrix.xml has a schema reference
- implements adding of the schema reference to the matrix.xml
- minor MatrixTest refactoring ("matrix.xml" is stored as a class constant now)