### PR TITLE
Implement LORM as described

### DIFF
--- a/src/main/resources/org/jpeek/metrics/LORM.xsl
+++ b/src/main/resources/org/jpeek/metrics/LORM.xsl
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- links between class methods -->
     <xsl:variable name="relations">
       <xsl:for-each select="$methods">
-        <xsl:variable name="from" select="@name" />
+        <xsl:variable name="from" select="@name"/>
         <xsl:for-each select="ops/op[@code='call'][starts-with(text(), $prefix)]">
           <xsl:variable name="to" select="substring-after(text(), $prefix)"/>
           <link from="{$from}" to="{$to}"/>

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -220,7 +220,8 @@ public final class MetricsTest {
             new Object[] {"OverloadMethods", "OCC", 0.75d},
             new Object[] {"TwoCommonAttributes", "OCC", 0.0d},
             new Object[] {"TwoCommonMethods", "OCC", 0.0d},
-            new Object[] {"WithoutAttributes", "OCC", 0.0d}
+            new Object[] {"WithoutAttributes", "OCC", 0.0d},
+            new Object[] {"TwoCommonMethods", "LORM", 0.26667d}
         );
     }
 

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -61,25 +61,25 @@ public final class LormTest {
             "N variable 'N' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
-            ).get(0),
+            ).stream().mapToInt(Integer::valueOf).toArray(),
             new IsEqual<>(
-                String.valueOf(methods)
+                new int[] { methods }
             )
         );
         MatcherAssert.assertThat(
             "variable 'R' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
-            ).get(0),
+            ).stream().mapToInt(Integer::valueOf).toArray(),
             new IsEqual<>(
-                String.valueOf(
-                    new String[] {
+                new int[] {
+                    new String[]{
                         "methodTwo   -> methodOne",
                         "methodThree -> methodOne",
                         "methodFive  -> methodFour",
                         "methodSix   -> methodFour",
                     }.length
-                )
+                }
             )
         );
         MatcherAssert.assertThat(

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -29,7 +29,7 @@ import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.jpeek.FakeBase;
 import org.jpeek.skeleton.Skeleton;
 import org.junit.Test;
@@ -58,20 +58,20 @@ public final class LormTest {
         );
         final int methods = 6;
         MatcherAssert.assertThat(
-            "N variable",
+            "N variable 'N' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
             ).get(0),
-            Matchers.equalTo(
+            new IsEqual<>(
                 String.valueOf(methods)
             )
         );
         MatcherAssert.assertThat(
-            "R variable",
+            "variable 'R' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
             ).get(0),
-            Matchers.equalTo(
+            new IsEqual<>(
                 String.valueOf(
                     new String[] {
                         "methodTwo   -> methodOne",
@@ -83,11 +83,11 @@ public final class LormTest {
             )
         );
         MatcherAssert.assertThat(
-            "RN variable = N * (N - 1) / 2",
+            String.format("variable 'RN' is not calculated correctly"),
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
             ).get(0),
-            Matchers.equalTo(
+            new IsEqual<>(
                 String.valueOf(
                     methods * (methods - 1) / 2
                 )

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -1,0 +1,97 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jpeek.metrics;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XSLDocument;
+import java.io.IOException;
+import org.cactoos.io.ResourceOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jpeek.FakeBase;
+import org.jpeek.skeleton.Skeleton;
+import org.junit.Test;
+
+/**
+ * Test case for LORM.
+ * LORM = Logical Relatedness of Methods.
+ * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
+ * @version $Id$
+ * @since 0.28
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class LormTest {
+
+    @Test
+    public void calculatesVariables() throws IOException {
+        final XML xml = new XSLDocument(
+            new ResourceOf(
+                "org/jpeek/metrics/LORM.xsl"
+            ).stream()
+        ).transform(
+            new Skeleton(
+                new FakeBase("TwoCommonMethods")
+            ).xml()
+        );
+        final int methods = 6;
+        MatcherAssert.assertThat(
+            "N variable",
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
+            ).get(0),
+            Matchers.equalTo(
+                String.valueOf(methods)
+            )
+        );
+        MatcherAssert.assertThat(
+            "R variable",
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
+            ).get(0),
+            Matchers.equalTo(
+                String.valueOf(
+                    new String[] {
+                        "methodTwo   -> methodOne",
+                        "methodThree -> methodOne",
+                        "methodFive  -> methodFour",
+                        "methodSix   -> methodFour",
+                    }.length
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "RN variable = N * (N - 1) / 2",
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
+            ).get(0),
+            Matchers.equalTo(
+                String.valueOf(
+                    methods * (methods - 1) / 2
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -26,8 +26,8 @@ package org.jpeek.metrics;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XSLDocument;
-import java.io.IOException;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.jpeek.FakeBase;
@@ -46,7 +46,7 @@ import org.junit.Test;
 public final class LormTest {
 
     @Test
-    public void calculatesVariables() throws IOException {
+    public void calculatesVariables() throws Exception {
         final XML xml = new XSLDocument(
             new ResourceOf(
                 "org/jpeek/metrics/LORM.xsl"
@@ -59,36 +59,46 @@ public final class LormTest {
         final int methods = 6;
         MatcherAssert.assertThat(
             "N variable 'N' is not calculated correctly",
-            xml.xpath(
-                "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
-            ).stream().mapToInt(Integer::valueOf).toArray(),
+            new ListOf<>(
+                xml.xpath(
+                    "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
+                ).stream().mapToInt(Integer::valueOf).iterator()
+            ),
             new IsEqual<>(
-                new int[] {methods}
+                new ListOf<>(
+                    methods
+                )
             )
         );
         MatcherAssert.assertThat(
             "variable 'R' is not calculated correctly",
-            xml.xpath(
-                "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
-            ).stream().mapToInt(Integer::valueOf).toArray(),
+            new ListOf<>(
+                xml.xpath(
+                    "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
+                ).stream().mapToInt(Integer::valueOf).iterator()
+            ),
             new IsEqual<>(
-                new int[] {
+                new ListOf<>(
                     new String[]{
                         "methodTwo   -> methodOne",
                         "methodThree -> methodOne",
                         "methodFive  -> methodFour",
-                        "methodSix   -> methodFour"
+                        "methodSix   -> methodFour",
                     }.length
-                }
+                )
             )
         );
         MatcherAssert.assertThat(
             "variable 'RN' is not calculated correctly",
-            xml.xpath(
-                "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
-            ).stream().mapToInt(Integer::valueOf).toArray(),
+            new ListOf<>(
+                xml.xpath(
+                    "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
+                ).stream().mapToInt(Integer::valueOf).iterator()
+            ),
             new IsEqual<>(
-                new int[] {methods * (methods - 1) / 2}
+                new ListOf<>(
+                    methods * (methods - 1) / 2
+                )
             )
         );
     }

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2018 Yegor Bugayenko
+ * Copyright (c) 2017-2019 Yegor Bugayenko
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,11 +86,9 @@ public final class LormTest {
             "variable 'RN' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
-            ).get(0),
+            ).stream().mapToInt(Integer::valueOf).toArray(),
             new IsEqual<>(
-                String.valueOf(
-                    methods * (methods - 1) / 2
-                )
+                new int[] {methods * (methods - 1) / 2}
             )
         );
     }

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -79,12 +79,12 @@ public final class LormTest {
             ),
             new IsEqual<>(
                 new ListOf<>(
-                    new String[]{
+                    new ListOf<>(
                         "methodTwo   -> methodOne",
                         "methodThree -> methodOne",
                         "methodFive  -> methodFour",
-                        "methodSix   -> methodFour",
-                    }.length
+                        "methodSix   -> methodFour"
+                    ).size()
                 )
             )
         );

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -59,26 +59,20 @@ public final class LormTest {
         final int methods = 6;
         MatcherAssert.assertThat(
             "N variable 'N' is not calculated correctly",
-            new ListOf<>(
-                xml.xpath(
-                    "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
-                ).stream().mapToInt(Integer::valueOf).iterator()
-            ),
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
+            ).get(0),
             new IsEqual<>(
-                new ListOf<>(
-                    methods
-                )
+                String.valueOf(methods)
             )
         );
         MatcherAssert.assertThat(
             "variable 'R' is not calculated correctly",
-            new ListOf<>(
-                xml.xpath(
-                    "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
-                ).stream().mapToInt(Integer::valueOf).iterator()
-            ),
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='R']/text()"
+            ).get(0),
             new IsEqual<>(
-                new ListOf<>(
+                String.valueOf(
                     new ListOf<>(
                         "methodTwo   -> methodOne",
                         "methodThree -> methodOne",
@@ -90,13 +84,11 @@ public final class LormTest {
         );
         MatcherAssert.assertThat(
             "variable 'RN' is not calculated correctly",
-            new ListOf<>(
-                xml.xpath(
-                    "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
-                ).stream().mapToInt(Integer::valueOf).iterator()
-            ),
+            xml.xpath(
+                "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
+            ).get(0),
             new IsEqual<>(
-                new ListOf<>(
+                String.valueOf(
                     methods * (methods - 1) / 2
                 )
             )

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -63,7 +63,7 @@ public final class LormTest {
                 "//class[@id='TwoCommonMethods']/vars/var[@id='N']/text()"
             ).stream().mapToInt(Integer::valueOf).toArray(),
             new IsEqual<>(
-                new int[] { methods }
+                new int[] {methods}
             )
         );
         MatcherAssert.assertThat(
@@ -77,7 +77,7 @@ public final class LormTest {
                         "methodTwo   -> methodOne",
                         "methodThree -> methodOne",
                         "methodFive  -> methodFour",
-                        "methodSix   -> methodFour",
+                        "methodSix   -> methodFour"
                     }.length
                 }
             )

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -83,7 +83,7 @@ public final class LormTest {
             )
         );
         MatcherAssert.assertThat(
-            String.format("variable 'RN' is not calculated correctly"),
+            "variable 'RN' is not calculated correctly",
             xml.xpath(
                 "//class[@id='TwoCommonMethods']/vars/var[@id='RN']/text()"
             ).get(0),

--- a/src/test/java/org/jpeek/metrics/package-info.java
+++ b/src/test/java/org/jpeek/metrics/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Individual metrics tests.
+ *
+ * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
+ * @version $Id$
+ * @since 0.28
+ */
+package org.jpeek.metrics;

--- a/src/test/java/org/jpeek/metrics/package-info.java
+++ b/src/test/java/org/jpeek/metrics/package-info.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2018 Yegor Bugayenko
+ * Copyright (c) 2017-2019 Yegor Bugayenko
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Currently, LORM metric is not implemented and not tested
although it seems to do something but definitely doesn't do what's
described in the paper and claimed in the description : (LORM = (R /
RN) where RN = N * (N - 1) / 2, N = total number of methods, R - method
relationships)

This PR:

- adds two unit tests for LORM: one as a parameter to the common
MetricsTest, another one for the specific metric LormTest
- implements the LORM metric according to the paper and the description