### PR TITLE
(#272) Update dependencies for Java 8+ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.0</version>
+      <version>6.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -249,7 +249,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.8</version>
+            <version>0.8.5</version>
             <configuration>
               <output>file</output>
             </configuration>


### PR DESCRIPTION
The following dependencies were breaking build on Java versions higher than 7:

- org.ow2.asm:asm:6.0 – broke on Java 8 and Java 11 (tested with Oracle JDK 1.8.0_231, OpenJDK 11.0.5), upgraded to 6.2.1 (latest 6.x version, assuming Semantic Versioning is in effect)
- org.jacoco:jacoco-maven-plugin:0.7.8 – broke on Java 11 (tested with OpenJDK 11.0.5), upgraded to 0.8.5 (latest current version, since all 0.7.x versions break on Java 11 as well)