### PR TITLE
#312 Update PR guidelines in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
 Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:
 
   - You made a small amount of changes (less than 100 lines, less than 10 files)
-  - You made changes related to only one bug (create separate PRs for separate problems)
+  - You made changes related to only one bug (create separate PRs for separate problems, or leave puzzles)
   - You are ready to defend your changes (there will be a code review)
   - You don't touch what you don't understand
   - You ran the build locally and it passed
+  - Title begins with the issue's number, then a short title
+  - Description begins with the issue's number, then enumerates the changes - summarized - in bulletpoints
+  - Description does not contain GitHub keywords (https://help.github.com/articles/closing-issues-using-keywords/).
 
 This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html
 

--- a/README.md
+++ b/README.md
@@ -263,5 +263,6 @@ if lost.
   - [@humb1t](https://github.com/humb1t) as Nikita Puzankov
   - [@stepanov-dmitry](https://github.com/stepanov-dmitry) as Dmitry Stepanov
   - [@GnusinPavel](https://github.com/GnusinPavel) as Gnusin Pavel
+  - [@mohamednizar](https://github.com/mohamednizar) as Mohamed Nizar
 
 Don't hesitate to add your name to this list in your next pull request.


### PR DESCRIPTION
#312 
- updated the PULL_REQUEST_TEMPLATE 

**Following new rules  are added**
- You made changes related to only one bug (create separate PRs for separate problems, or leave puzzles)
- You ran the build locally and it passed
- Title begins with the issue's number, then a short title
- Description begins with the issue's number, then enumerates the changes - summarized - in bulletpoints
- Description does not contain GitHub keywords (https://help.github.com/articles/closing-issues-using-keywords/).