### PR TITLE
Update maven-compiler-plugin to 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,9 +240,11 @@ SOFTWARE.
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
+            <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
This PR is related to issue #324 and allows incremental compilation for `maven-compiler-plugin` adding appropriate plugin key into `pom.xml`