### PR TITLE
357

### DIFF
--- a/src/main/java/org/jpeek/App.java
+++ b/src/main/java/org/jpeek/App.java
@@ -65,7 +65,6 @@ import org.xembly.Xembler;
  * @checkstyle CyclomaticComplexityCheck (500 lines)
  * @checkstyle MethodLengthCheck (500 lines)
  * @checkstyle JavaNCSSCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  *
  * @todo #118:30min LCC metric has impediments (see puzzles in LCC.xml
  *  and in `MetricsTest`).

--- a/src/main/java/org/jpeek/App.java
+++ b/src/main/java/org/jpeek/App.java
@@ -56,8 +56,6 @@ import org.xembly.Xembler;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)

--- a/src/main/java/org/jpeek/Base.java
+++ b/src/main/java/org/jpeek/Base.java
@@ -32,8 +32,6 @@ import org.cactoos.iterable.Joined;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/Base.java
+++ b/src/main/java/org/jpeek/Base.java
@@ -33,7 +33,6 @@ import org.cactoos.iterable.Joined;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public interface Base {
 

--- a/src/main/java/org/jpeek/Base.java
+++ b/src/main/java/org/jpeek/Base.java
@@ -33,6 +33,7 @@ import org.cactoos.iterable.Joined;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
+ * @checkstyle JavadocTagsCheck (500 lines)
  */
 public interface Base {
 

--- a/src/main/java/org/jpeek/DefaultBase.java
+++ b/src/main/java/org/jpeek/DefaultBase.java
@@ -36,8 +36,6 @@ import java.util.stream.Stream;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/DefaultBase.java
+++ b/src/main/java/org/jpeek/DefaultBase.java
@@ -37,7 +37,6 @@ import java.util.stream.Stream;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class DefaultBase implements Base {
 

--- a/src/main/java/org/jpeek/FileTarget.java
+++ b/src/main/java/org/jpeek/FileTarget.java
@@ -33,8 +33,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * File Target.
- * @author Felipe Moreno (oridan@gmail.com)
- * @version $Id$
  * @since 0.26.4
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/FileTarget.java
+++ b/src/main/java/org/jpeek/FileTarget.java
@@ -34,7 +34,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 /**
  * File Target.
  * @since 0.26.4
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class FileTarget implements Target {
 

--- a/src/main/java/org/jpeek/Header.java
+++ b/src/main/java/org/jpeek/Header.java
@@ -35,8 +35,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/Header.java
+++ b/src/main/java/org/jpeek/Header.java
@@ -37,7 +37,6 @@ import org.xembly.Directives;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class Header implements Iterable<Directive> {
 

--- a/src/main/java/org/jpeek/Index.java
+++ b/src/main/java/org/jpeek/Index.java
@@ -42,8 +42,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/Index.java
+++ b/src/main/java/org/jpeek/Index.java
@@ -44,7 +44,6 @@ import org.xembly.Directives;
  *
  * @since 0.6
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Index implements Iterable<Directive> {
 

--- a/src/main/java/org/jpeek/Main.java
+++ b/src/main/java/org/jpeek/Main.java
@@ -45,7 +45,6 @@ import org.apache.log4j.PatternLayout;
  *  author, version and since tags in all javadoc. After that remove
  *  'JavadocTagsCheck' suppression.
  * @checkstyle JavadocVariableCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class Main {
 

--- a/src/main/java/org/jpeek/Main.java
+++ b/src/main/java/org/jpeek/Main.java
@@ -40,10 +40,6 @@ import org.apache.log4j.PatternLayout;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
- * @todo #308:30min Due to introduce new version of qulice 0.18.17 there were
- *  many 'JavadocTagsCheck' suppression, so we need to fix that by remove
- *  author, version and since tags in all javadoc. After that remove
- *  'JavadocTagsCheck' suppression.
  * @checkstyle JavadocVariableCheck (500 lines)
  */
 public final class Main {

--- a/src/main/java/org/jpeek/Main.java
+++ b/src/main/java/org/jpeek/Main.java
@@ -39,8 +39,6 @@ import org.apache.log4j.PatternLayout;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @todo #308:30min Due to introduce new version of qulice 0.18.17 there were
  *  many 'JavadocTagsCheck' suppression, so we need to fix that by remove

--- a/src/main/java/org/jpeek/Matrix.java
+++ b/src/main/java/org/jpeek/Matrix.java
@@ -43,8 +43,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/Matrix.java
+++ b/src/main/java/org/jpeek/Matrix.java
@@ -45,7 +45,6 @@ import org.xembly.Directives;
  *
  * @since 0.6
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Matrix implements Iterable<Directive> {
 

--- a/src/main/java/org/jpeek/Report.java
+++ b/src/main/java/org/jpeek/Report.java
@@ -52,8 +52,6 @@ import org.xembly.Xembler;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/Report.java
+++ b/src/main/java/org/jpeek/Report.java
@@ -54,7 +54,6 @@ import org.xembly.Xembler;
  *
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Report {
     /**

--- a/src/main/java/org/jpeek/ReportWithStatistics.java
+++ b/src/main/java/org/jpeek/ReportWithStatistics.java
@@ -40,8 +40,6 @@ import org.xembly.Xembler;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/ReportWithStatistics.java
+++ b/src/main/java/org/jpeek/ReportWithStatistics.java
@@ -42,7 +42,6 @@ import org.xembly.Xembler;
  *
  * @since 0.16
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class ReportWithStatistics implements XML {
 

--- a/src/main/java/org/jpeek/Target.java
+++ b/src/main/java/org/jpeek/Target.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
  * File Target.
  *
  * @since 0.26.4
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public interface Target {
 

--- a/src/main/java/org/jpeek/Target.java
+++ b/src/main/java/org/jpeek/Target.java
@@ -29,8 +29,6 @@ import java.nio.file.Path;
 /**
  * File Target.
  *
- * @author Felipe Moreno (oridan@gmail.com)
- * @version $Id$
  * @since 0.26.4
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/Version.java
+++ b/src/main/java/org/jpeek/Version.java
@@ -33,8 +33,6 @@ import org.cactoos.scalar.PropertiesOf;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/Version.java
+++ b/src/main/java/org/jpeek/Version.java
@@ -35,7 +35,6 @@ import org.cactoos.scalar.PropertiesOf;
  *
  * @since 0.11
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class Version implements Scalar<String> {
 

--- a/src/main/java/org/jpeek/package-info.java
+++ b/src/main/java/org/jpeek/package-info.java
@@ -25,8 +25,6 @@
 /**
  * JPeek.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @see <a href="https://www.jpeek.org">Project site www.jpeek.org</a>
  * @see <a href="https://github.com/yegor256/jpeek">GitHub repository</a>

--- a/src/main/java/org/jpeek/skeleton/Classes.java
+++ b/src/main/java/org/jpeek/skeleton/Classes.java
@@ -49,7 +49,6 @@ import org.jpeek.Base;
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Classes implements Iterable<CtClass> {
 

--- a/src/main/java/org/jpeek/skeleton/Classes.java
+++ b/src/main/java/org/jpeek/skeleton/Classes.java
@@ -45,8 +45,6 @@ import org.jpeek.Base;
  *
  * <p>There is no thread-safety guarantee.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A packages suite for object oriented design</a>
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/main/java/org/jpeek/skeleton/OpsOf.java
+++ b/src/main/java/org/jpeek/skeleton/OpsOf.java
@@ -39,7 +39,6 @@ import org.xembly.Directives;
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ParameterNumberCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class OpsOf extends MethodVisitor {

--- a/src/main/java/org/jpeek/skeleton/OpsOf.java
+++ b/src/main/java/org/jpeek/skeleton/OpsOf.java
@@ -34,8 +34,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A packages suite for object oriented design</a>
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/main/java/org/jpeek/skeleton/QualifiedName.java
+++ b/src/main/java/org/jpeek/skeleton/QualifiedName.java
@@ -32,7 +32,6 @@ import org.cactoos.text.UncheckedText;
  * that specifies field without regard
  * to the context of the call.
  * @since 0.29
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class QualifiedName extends TextEnvelope {
     /**

--- a/src/main/java/org/jpeek/skeleton/QualifiedName.java
+++ b/src/main/java/org/jpeek/skeleton/QualifiedName.java
@@ -31,8 +31,6 @@ import org.cactoos.text.UncheckedText;
  * A fully qualified name of a field, an unambiguous name
  * that specifies field without regard
  * to the context of the call.
- * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
- * @version $Id$
  * @since 0.29
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/skeleton/Skeleton.java
+++ b/src/main/java/org/jpeek/skeleton/Skeleton.java
@@ -52,8 +52,6 @@ import org.xembly.Xembler;
  *
  * <p>There is no thread-safety guarantee.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A packages suite for object oriented design</a>
  * @since 0.23
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/main/java/org/jpeek/skeleton/Skeleton.java
+++ b/src/main/java/org/jpeek/skeleton/Skeleton.java
@@ -56,7 +56,6 @@ import org.xembly.Xembler;
  * @since 0.23
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class Skeleton {
 

--- a/src/main/java/org/jpeek/skeleton/TypesOf.java
+++ b/src/main/java/org/jpeek/skeleton/TypesOf.java
@@ -39,8 +39,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A packages suite for object oriented design</a>
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/main/java/org/jpeek/skeleton/TypesOf.java
+++ b/src/main/java/org/jpeek/skeleton/TypesOf.java
@@ -43,7 +43,6 @@ import org.xembly.Directives;
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TypesOf extends SignatureVisitor implements Iterable<Directive> {
 

--- a/src/main/java/org/jpeek/skeleton/XmlClass.java
+++ b/src/main/java/org/jpeek/skeleton/XmlClass.java
@@ -44,8 +44,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.pitt.edu/~ckemerer/CK%20research%20papers/MetricForOOD_ChidamberKemerer94.pdf">A packages suite for object oriented design</a>
  * @since 0.27
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/main/java/org/jpeek/skeleton/XmlClass.java
+++ b/src/main/java/org/jpeek/skeleton/XmlClass.java
@@ -49,7 +49,6 @@ import org.xembly.Directives;
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ParameterNumberCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class XmlClass extends ClassVisitor implements Iterable<Directive> {

--- a/src/main/java/org/jpeek/skeleton/package-info.java
+++ b/src/main/java/org/jpeek/skeleton/package-info.java
@@ -25,8 +25,6 @@
 /**
  * Skeleton.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.27
  */
 package org.jpeek.skeleton;

--- a/src/main/java/org/jpeek/web/AsyncReports.java
+++ b/src/main/java/org/jpeek/web/AsyncReports.java
@@ -44,8 +44,6 @@ import org.takes.rs.xe.XeAppend;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/AsyncReports.java
+++ b/src/main/java/org/jpeek/web/AsyncReports.java
@@ -46,7 +46,6 @@ import org.takes.rs.xe.XeAppend;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class AsyncReports implements

--- a/src/main/java/org/jpeek/web/DyNum.java
+++ b/src/main/java/org/jpeek/web/DyNum.java
@@ -34,8 +34,6 @@ import java.io.IOException;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/DyNum.java
+++ b/src/main/java/org/jpeek/web/DyNum.java
@@ -36,7 +36,6 @@ import java.io.IOException;
  *
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class DyNum extends Number {
 

--- a/src/main/java/org/jpeek/web/Dynamo.java
+++ b/src/main/java/org/jpeek/web/Dynamo.java
@@ -39,8 +39,6 @@ import org.cactoos.scalar.PropertiesOf;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Dynamo.java
+++ b/src/main/java/org/jpeek/web/Dynamo.java
@@ -41,7 +41,6 @@ import org.cactoos.scalar.PropertiesOf;
  *
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class Dynamo implements Region {

--- a/src/main/java/org/jpeek/web/Futures.java
+++ b/src/main/java/org/jpeek/web/Futures.java
@@ -52,8 +52,6 @@ import org.takes.rs.xe.XeAppend;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Futures.java
+++ b/src/main/java/org/jpeek/web/Futures.java
@@ -54,7 +54,6 @@ import org.takes.rs.xe.XeAppend;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Futures implements
     BiFunc<String, String, Future<Func<String, Response>>>, Text {

--- a/src/main/java/org/jpeek/web/Mistakes.java
+++ b/src/main/java/org/jpeek/web/Mistakes.java
@@ -48,8 +48,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Mistakes.java
+++ b/src/main/java/org/jpeek/web/Mistakes.java
@@ -50,7 +50,6 @@ import org.xembly.Directives;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class Mistakes {

--- a/src/main/java/org/jpeek/web/Pages.java
+++ b/src/main/java/org/jpeek/web/Pages.java
@@ -35,8 +35,6 @@ import org.takes.rs.RsWithBody;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Pages.java
+++ b/src/main/java/org/jpeek/web/Pages.java
@@ -37,7 +37,6 @@ import org.takes.rs.RsWithBody;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Pages implements Func<String, Response> {
 

--- a/src/main/java/org/jpeek/web/Reports.java
+++ b/src/main/java/org/jpeek/web/Reports.java
@@ -48,7 +48,6 @@ import org.takes.Response;
  *
  * @since 0.7
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class Reports implements BiFunc<String, String, Func<String, Response>> {
 

--- a/src/main/java/org/jpeek/web/Reports.java
+++ b/src/main/java/org/jpeek/web/Reports.java
@@ -46,8 +46,6 @@ import org.takes.Response;
  * thread-safe. You have to decorate it with a thread-safe
  * {@link Futures}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.7
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Results.java
+++ b/src/main/java/org/jpeek/web/Results.java
@@ -52,7 +52,6 @@ import org.xembly.Directives;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class Results {

--- a/src/main/java/org/jpeek/web/Results.java
+++ b/src/main/java/org/jpeek/web/Results.java
@@ -50,8 +50,6 @@ import org.xembly.Directives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/RsPage.java
+++ b/src/main/java/org/jpeek/web/RsPage.java
@@ -47,8 +47,6 @@ import org.takes.rs.xe.XeStylesheet;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/RsPage.java
+++ b/src/main/java/org/jpeek/web/RsPage.java
@@ -49,7 +49,6 @@ import org.takes.rs.xe.XeStylesheet;
  *
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class RsPage extends RsWrap {
 

--- a/src/main/java/org/jpeek/web/Sigmas.java
+++ b/src/main/java/org/jpeek/web/Sigmas.java
@@ -44,8 +44,6 @@ import org.jpeek.Version;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/Sigmas.java
+++ b/src/main/java/org/jpeek/web/Sigmas.java
@@ -46,7 +46,6 @@ import org.jpeek.Version;
  *
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class Sigmas {

--- a/src/main/java/org/jpeek/web/StickyFutures.java
+++ b/src/main/java/org/jpeek/web/StickyFutures.java
@@ -37,7 +37,6 @@ import org.takes.Response;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class StickyFutures
     implements BiFunc<String, String, Future<Func<String, Response>>> {

--- a/src/main/java/org/jpeek/web/StickyFutures.java
+++ b/src/main/java/org/jpeek/web/StickyFutures.java
@@ -35,8 +35,6 @@ import org.takes.Response;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkAll.java
+++ b/src/main/java/org/jpeek/web/TkAll.java
@@ -38,7 +38,6 @@ import org.takes.rs.xe.XeDirectives;
  *
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkAll implements Take {
 

--- a/src/main/java/org/jpeek/web/TkAll.java
+++ b/src/main/java/org/jpeek/web/TkAll.java
@@ -36,8 +36,6 @@ import org.takes.rs.xe.XeDirectives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkApp.java
+++ b/src/main/java/org/jpeek/web/TkApp.java
@@ -58,8 +58,6 @@ import org.takes.tk.TkWrap;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkApp.java
+++ b/src/main/java/org/jpeek/web/TkApp.java
@@ -61,7 +61,6 @@ import org.takes.tk.TkWrap;
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.UseUtilityClass")
 public final class TkApp extends TkWrap {

--- a/src/main/java/org/jpeek/web/TkIndex.java
+++ b/src/main/java/org/jpeek/web/TkIndex.java
@@ -39,7 +39,6 @@ import org.takes.rs.xe.XeDirectives;
  *
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkIndex implements Take {
 

--- a/src/main/java/org/jpeek/web/TkIndex.java
+++ b/src/main/java/org/jpeek/web/TkIndex.java
@@ -37,8 +37,6 @@ import org.takes.rs.xe.XeDirectives;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkMistakes.java
+++ b/src/main/java/org/jpeek/web/TkMistakes.java
@@ -38,8 +38,6 @@ import org.xembly.Directive;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkMistakes.java
+++ b/src/main/java/org/jpeek/web/TkMistakes.java
@@ -40,7 +40,6 @@ import org.xembly.Directive;
  *
  * @since 0.14
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkMistakes implements Take {
 

--- a/src/main/java/org/jpeek/web/TkQueue.java
+++ b/src/main/java/org/jpeek/web/TkQueue.java
@@ -36,7 +36,6 @@ import org.takes.rs.RsText;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.18
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkQueue implements Take {
 

--- a/src/main/java/org/jpeek/web/TkQueue.java
+++ b/src/main/java/org/jpeek/web/TkQueue.java
@@ -35,8 +35,6 @@ import org.takes.rs.RsText;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.18
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/web/TkReport.java
+++ b/src/main/java/org/jpeek/web/TkReport.java
@@ -51,7 +51,6 @@ import org.xembly.Xembler;
  *
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkReport implements TkRegex {
 

--- a/src/main/java/org/jpeek/web/TkReport.java
+++ b/src/main/java/org/jpeek/web/TkReport.java
@@ -49,8 +49,6 @@ import org.xembly.Xembler;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TkUpload.java
+++ b/src/main/java/org/jpeek/web/TkUpload.java
@@ -42,7 +42,6 @@ import org.takes.rs.RsText;
  *
  * @since 0.32
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TkUpload implements Take {
 

--- a/src/main/java/org/jpeek/web/TkUpload.java
+++ b/src/main/java/org/jpeek/web/TkUpload.java
@@ -40,8 +40,6 @@ import org.takes.rs.RsText;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.32
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/TypedPages.java
+++ b/src/main/java/org/jpeek/web/TypedPages.java
@@ -36,7 +36,6 @@ import org.takes.rs.RsWithType;
  *
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 final class TypedPages implements Func<String, Response> {
 

--- a/src/main/java/org/jpeek/web/TypedPages.java
+++ b/src/main/java/org/jpeek/web/TypedPages.java
@@ -34,8 +34,6 @@ import org.takes.rs.RsWithType;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/main/java/org/jpeek/web/package-info.java
+++ b/src/main/java/org/jpeek/web/package-info.java
@@ -25,8 +25,6 @@
 /**
  * JPeek web.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.7
  */
 package org.jpeek.web;

--- a/src/test/java/org/jpeek/AppTest.java
+++ b/src/test/java/org/jpeek/AppTest.java
@@ -46,7 +46,6 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * Test case for {@link App}.
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/org/jpeek/AppTest.java
+++ b/src/test/java/org/jpeek/AppTest.java
@@ -44,8 +44,6 @@ import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
  * Test case for {@link App}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/DefaultBaseTest.java
+++ b/src/test/java/org/jpeek/DefaultBaseTest.java
@@ -33,8 +33,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link DefaultBase}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/DefaultBaseTest.java
+++ b/src/test/java/org/jpeek/DefaultBaseTest.java
@@ -35,7 +35,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link DefaultBase}.
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class DefaultBaseTest {
 

--- a/src/test/java/org/jpeek/FakeBase.java
+++ b/src/test/java/org/jpeek/FakeBase.java
@@ -37,8 +37,6 @@ import org.cactoos.scalar.LengthOf;
 
 /**
  * Fake base for tests.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle JavadocMethodCheck (500 lines)

--- a/src/test/java/org/jpeek/FakeBase.java
+++ b/src/test/java/org/jpeek/FakeBase.java
@@ -41,7 +41,6 @@ import org.cactoos.scalar.LengthOf;
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class FakeBase implements Base {
 

--- a/src/test/java/org/jpeek/IndexTest.java
+++ b/src/test/java/org/jpeek/IndexTest.java
@@ -37,7 +37,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link Index}.
  * @since 0.6
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class IndexTest {
     /**

--- a/src/test/java/org/jpeek/IndexTest.java
+++ b/src/test/java/org/jpeek/IndexTest.java
@@ -35,8 +35,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link Index}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/MainTest.java
+++ b/src/test/java/org/jpeek/MainTest.java
@@ -36,8 +36,6 @@ import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Main}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/MainTest.java
+++ b/src/test/java/org/jpeek/MainTest.java
@@ -38,7 +38,6 @@ import org.llorllale.cactoos.matchers.Throws;
  * Test case for {@link Main}.
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class MainTest {

--- a/src/test/java/org/jpeek/MatrixTest.java
+++ b/src/test/java/org/jpeek/MatrixTest.java
@@ -37,7 +37,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link Matrix}.
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class MatrixTest {
     /**

--- a/src/test/java/org/jpeek/MatrixTest.java
+++ b/src/test/java/org/jpeek/MatrixTest.java
@@ -35,8 +35,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link Matrix}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -54,7 +54,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  *  Also, all classes without transitive relations
  *  should have the same LCC metric as TCC metric.
  *  Before do it we have to fix puzzles in LCC.xml.
- *  @checkstyle JavadocTagsCheck (500 lines)
  */
 @RunWith(Parameterized.class)
 @SuppressWarnings(

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -43,8 +43,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 //  OneMethodCreatesLambda.
 /**
  * Tests for all metrics.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.23
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle VisibilityModifierCheck (500 lines)

--- a/src/test/java/org/jpeek/ReportTest.java
+++ b/src/test/java/org/jpeek/ReportTest.java
@@ -38,8 +38,6 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link Report}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/jpeek/ReportTest.java
+++ b/src/test/java/org/jpeek/ReportTest.java
@@ -41,7 +41,6 @@ import org.xembly.Xembler;
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ReportTest {

--- a/src/test/java/org/jpeek/ReportWithStatisticsTest.java
+++ b/src/test/java/org/jpeek/ReportWithStatisticsTest.java
@@ -34,8 +34,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link ReportWithStatistics}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.19
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/ReportWithStatisticsTest.java
+++ b/src/test/java/org/jpeek/ReportWithStatisticsTest.java
@@ -36,7 +36,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link ReportWithStatistics}.
  * @since 0.19
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class ReportWithStatisticsTest {
 

--- a/src/test/java/org/jpeek/metrics/Lcom4Test.java
+++ b/src/test/java/org/jpeek/metrics/Lcom4Test.java
@@ -34,8 +34,6 @@ import org.junit.Test;
  * Basically it's a graph disjoint set.
  * I.e. it answers the the following question:
  * "Into how many independent classes can you split this class?"
- * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
- * @version $Id$
  * @since 0.28
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/jpeek/metrics/Lcom4Test.java
+++ b/src/test/java/org/jpeek/metrics/Lcom4Test.java
@@ -38,7 +38,6 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class Lcom4Test {
 

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
  * @since 0.28
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class LormTest {
     @Test

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -30,8 +30,6 @@ import org.junit.Test;
 /**
  * Test case for LORM.
  * LORM = Logical Relatedness of Methods.
- * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
- * @version $Id$
  * @since 0.28
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/jpeek/metrics/MetricBase.java
+++ b/src/test/java/org/jpeek/metrics/MetricBase.java
@@ -38,7 +38,6 @@ import org.llorllale.cactoos.matchers.TextIs;
 /**
  * Metric test helper.
  * @since 0.28
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class MetricBase {
     /**

--- a/src/test/java/org/jpeek/metrics/MetricBase.java
+++ b/src/test/java/org/jpeek/metrics/MetricBase.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.TextIs;
 /**
  * Metric test helper.
  * @since 0.28
+ * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class MetricBase {
     /**

--- a/src/test/java/org/jpeek/metrics/MetricBase.java
+++ b/src/test/java/org/jpeek/metrics/MetricBase.java
@@ -37,8 +37,6 @@ import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Metric test helper.
- * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
- * @version $Id$
  * @since 0.28
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/test/java/org/jpeek/metrics/package-info.java
+++ b/src/test/java/org/jpeek/metrics/package-info.java
@@ -25,8 +25,6 @@
 /**
  * Individual metrics tests.
  *
- * @author Ilya Kharlamov (ilya.kharlamov@gmail.com)
- * @version $Id$
  * @since 0.28
  */
 package org.jpeek.metrics;

--- a/src/test/java/org/jpeek/package-info.java
+++ b/src/test/java/org/jpeek/package-info.java
@@ -25,8 +25,6 @@
 /**
  * Tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.jpeek;

--- a/src/test/java/org/jpeek/skeleton/SkeletonTest.java
+++ b/src/test/java/org/jpeek/skeleton/SkeletonTest.java
@@ -38,7 +38,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  *  findFieldWithQualifiedName must be uncommented when this issue is
  *  resolved. Please see #156 for more detailing in upgrading skeleton
  *  behavior.
- *  @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SkeletonTest {

--- a/src/test/java/org/jpeek/skeleton/SkeletonTest.java
+++ b/src/test/java/org/jpeek/skeleton/SkeletonTest.java
@@ -31,8 +31,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link Skeleton}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.23
  * @checkstyle JavadocMethodCheck (500 lines)
  * @todo #156:30min Skeleton must be upgraded to determine if a field being

--- a/src/test/java/org/jpeek/skeleton/TypesOfTest.java
+++ b/src/test/java/org/jpeek/skeleton/TypesOfTest.java
@@ -33,7 +33,6 @@ import org.xembly.Xembler;
  * Test case for {@link TypesOf}.
  * @since 0.27
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TypesOfTest {
 

--- a/src/test/java/org/jpeek/skeleton/TypesOfTest.java
+++ b/src/test/java/org/jpeek/skeleton/TypesOfTest.java
@@ -31,8 +31,6 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link TypesOf}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.27
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/skeleton/XmlClassTest.java
+++ b/src/test/java/org/jpeek/skeleton/XmlClassTest.java
@@ -29,8 +29,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link XmlClass}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.27
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/skeleton/XmlClassTest.java
+++ b/src/test/java/org/jpeek/skeleton/XmlClassTest.java
@@ -31,7 +31,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link XmlClass}.
  * @since 0.27
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class XmlClassTest {

--- a/src/test/java/org/jpeek/skeleton/package-info.java
+++ b/src/test/java/org/jpeek/skeleton/package-info.java
@@ -25,8 +25,6 @@
 /**
  * Skeleton, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.27
  */
 package org.jpeek.skeleton;

--- a/src/test/java/org/jpeek/web/AsyncReportsTest.java
+++ b/src/test/java/org/jpeek/web/AsyncReportsTest.java
@@ -40,8 +40,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link AsyncReports}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/AsyncReportsTest.java
+++ b/src/test/java/org/jpeek/web/AsyncReportsTest.java
@@ -42,7 +42,6 @@ import org.takes.rs.RsText;
  * Test case for {@link AsyncReports}.
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class AsyncReportsTest {
 

--- a/src/test/java/org/jpeek/web/DyNumTest.java
+++ b/src/test/java/org/jpeek/web/DyNumTest.java
@@ -31,8 +31,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link DyNum}.
- * @author Nikita Puzankov (humb1t@yandex.ru)
- * @version $Id$
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/DyNumTest.java
+++ b/src/test/java/org/jpeek/web/DyNumTest.java
@@ -33,7 +33,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link DyNum}.
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class DyNumTest {
 

--- a/src/test/java/org/jpeek/web/FuturesTest.java
+++ b/src/test/java/org/jpeek/web/FuturesTest.java
@@ -35,7 +35,6 @@ import org.takes.rs.xe.XeAppend;
  * Test case for {@link Futures}.
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class FuturesTest {

--- a/src/test/java/org/jpeek/web/FuturesTest.java
+++ b/src/test/java/org/jpeek/web/FuturesTest.java
@@ -33,8 +33,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link Futures}.
- * @author Nikita Puzankov (humb1t@yandex.ru)
- * @version $Id$
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/MistakesTest.java
+++ b/src/test/java/org/jpeek/web/MistakesTest.java
@@ -37,8 +37,6 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link Mistakes}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/MistakesTest.java
+++ b/src/test/java/org/jpeek/web/MistakesTest.java
@@ -39,7 +39,6 @@ import org.xembly.Xembler;
  * Test case for {@link Mistakes}.
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class MistakesTest {
 

--- a/src/test/java/org/jpeek/web/PagesTest.java
+++ b/src/test/java/org/jpeek/web/PagesTest.java
@@ -33,8 +33,6 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link Pages}.
- * @author Nikita Puzankov (humb1t@yandex.ru)
- * @version $Id$
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/PagesTest.java
+++ b/src/test/java/org/jpeek/web/PagesTest.java
@@ -35,7 +35,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link Pages}.
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class PagesTest {
 

--- a/src/test/java/org/jpeek/web/ReportsTest.java
+++ b/src/test/java/org/jpeek/web/ReportsTest.java
@@ -42,7 +42,6 @@ import org.takes.facets.hamcrest.HmRsStatus;
  * Test case for {@link Reports}.
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ReportsTest {

--- a/src/test/java/org/jpeek/web/ReportsTest.java
+++ b/src/test/java/org/jpeek/web/ReportsTest.java
@@ -40,8 +40,6 @@ import org.takes.facets.hamcrest.HmRsStatus;
 
 /**
  * Test case for {@link Reports}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/ResultsTest.java
+++ b/src/test/java/org/jpeek/web/ResultsTest.java
@@ -39,7 +39,6 @@ import org.xembly.Xembler;
  * Test case for {@link Results}.
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class ResultsTest {
 

--- a/src/test/java/org/jpeek/web/ResultsTest.java
+++ b/src/test/java/org/jpeek/web/ResultsTest.java
@@ -37,8 +37,6 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link Results}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkAllTest.java
+++ b/src/test/java/org/jpeek/web/TkAllTest.java
@@ -32,8 +32,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkAll}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkAllTest.java
+++ b/src/test/java/org/jpeek/web/TkAllTest.java
@@ -34,7 +34,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkAll}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TkAllTest {
 

--- a/src/test/java/org/jpeek/web/TkAppTest.java
+++ b/src/test/java/org/jpeek/web/TkAppTest.java
@@ -38,8 +38,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkApp}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkAppTest.java
+++ b/src/test/java/org/jpeek/web/TkAppTest.java
@@ -40,7 +40,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkApp}.
  * @since 0.5
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TkAppTest {
 

--- a/src/test/java/org/jpeek/web/TkIndexTest.java
+++ b/src/test/java/org/jpeek/web/TkIndexTest.java
@@ -34,7 +34,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkIndex}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TkIndexTest {
 

--- a/src/test/java/org/jpeek/web/TkIndexTest.java
+++ b/src/test/java/org/jpeek/web/TkIndexTest.java
@@ -32,8 +32,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkIndex}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkMistakesTest.java
+++ b/src/test/java/org/jpeek/web/TkMistakesTest.java
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkMistakes}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkMistakesTest.java
+++ b/src/test/java/org/jpeek/web/TkMistakesTest.java
@@ -35,7 +35,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkMistakes}.
  * @since 0.14
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TkMistakesTest {
 

--- a/src/test/java/org/jpeek/web/TkReportTest.java
+++ b/src/test/java/org/jpeek/web/TkReportTest.java
@@ -35,8 +35,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkReport}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.23
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkReportTest.java
+++ b/src/test/java/org/jpeek/web/TkReportTest.java
@@ -37,7 +37,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkReport}.
  * @since 0.23
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkReportTest {

--- a/src/test/java/org/jpeek/web/TkUploadTest.java
+++ b/src/test/java/org/jpeek/web/TkUploadTest.java
@@ -34,8 +34,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkUpload}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)

--- a/src/test/java/org/jpeek/web/TkUploadTest.java
+++ b/src/test/java/org/jpeek/web/TkUploadTest.java
@@ -36,7 +36,6 @@ import org.takes.rs.RsPrint;
  * Test case for {@link TkUpload}.
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTagsCheck (500 lines)
  */
 public final class TkUploadTest {
 

--- a/src/test/java/org/jpeek/web/package-info.java
+++ b/src/test/java/org/jpeek/web/package-info.java
@@ -25,8 +25,6 @@
 /**
  * JPeek web, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.7
  */
 package org.jpeek.web;


### PR DESCRIPTION
Issue [#357](https://github.com/yegor256/jpeek/issues/357)

We cannot remove the 'since' tag because it is mandatory for the current check style policy.

Additionally, I've created the [issue](https://github.com/teamed/qulice/issues/1071) in qulice. 
That is why I didn't remove the JavadocTagsCheck tag from Base.java and DefaultBase.java.