### PR TITLE
resolve puzzle #380 migrate tests to junit 5

### DIFF
--- a/src/test/java/org/jpeek/metrics/Lcom4Test.java
+++ b/src/test/java/org/jpeek/metrics/Lcom4Test.java
@@ -25,8 +25,8 @@
 package org.jpeek.metrics;
 
 import org.cactoos.list.ListOf;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for LCOM4
@@ -84,7 +84,7 @@ public final class Lcom4Test {
      *  After implementing, remove the @Ignore.
      */
     @Test
-    @Ignore
+    @Disabled
     public void methodMethodCalls() throws Exception {
         final MetricBase.Report report = new MetricBase(
             Lcom4Test.XSL

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -25,7 +25,7 @@
 package org.jpeek.metrics;
 
 import org.cactoos.list.ListOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for LORM.

--- a/src/test/java/org/jpeek/package-info.java
+++ b/src/test/java/org/jpeek/package-info.java
@@ -28,9 +28,10 @@
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
- * @todo #323:30min Migrate the tests in the sub-packages: org.jpeek.metrics,
- *  org.jpeek.skeleton and org.jpeek.web to junit 5, so they won't
- *  import any classes from junit 4 anymore. Then, we should find a way to
- *  exclude junit 4 from project dependecy, so they won't be imported anymore.
+ * @todo #380:30min Migrate the tests in the remaining sub-package
+ *  org.jpeek.web to junit 5, so they won't import any classes from Junit 4
+ *  anymore. Once we have no more Junit 4 tests, we can remove
+ *  junit-vintage-engine dependency. Ideally, we should find a way to exclude
+ *  junit 4 from project dependecy, so its API won't be imported anymore.
  */
 package org.jpeek;

--- a/src/test/java/org/jpeek/skeleton/SkeletonTest.java
+++ b/src/test/java/org/jpeek/skeleton/SkeletonTest.java
@@ -26,7 +26,7 @@ package org.jpeek.skeleton;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.jpeek.Base;
 import org.jpeek.FakeBase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**

--- a/src/test/java/org/jpeek/skeleton/TypesOfTest.java
+++ b/src/test/java/org/jpeek/skeleton/TypesOfTest.java
@@ -24,7 +24,7 @@
 package org.jpeek.skeleton;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.xembly.Directives;
 import org.xembly.Xembler;

--- a/src/test/java/org/jpeek/skeleton/XmlClassTest.java
+++ b/src/test/java/org/jpeek/skeleton/XmlClassTest.java
@@ -24,7 +24,7 @@
 package org.jpeek.skeleton;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**


### PR DESCRIPTION
Resolving puzzle #380 
Migrate tests on 2 packages.
Update the puzzle to:
* include only the last package to migrate
* once completed, remove junit-vintage-engine dependency
* optionally/ideally find a way to exclude junit 4 dependency.