### PR TITLE
#355 Add puzzles check on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
     - $HOME/.m2
 script:
   - set -e
+  - pdd -f /dev/null
   - mvn clean site -Psite --errors --batch-mode
   - mvn clean install -Pqulice --errors --batch-mode
 install:

--- a/src/main/java/org/jpeek/Report.java
+++ b/src/main/java/org/jpeek/Report.java
@@ -55,9 +55,9 @@ import org.xembly.Xembler;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @todo #355:30min too short puzzle
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)
- * @todo #355:30min too short puzzle
  */
 final class Report {
     /**

--- a/src/main/java/org/jpeek/Report.java
+++ b/src/main/java/org/jpeek/Report.java
@@ -55,7 +55,6 @@ import org.xembly.Xembler;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
- * @todo #355:30min too short puzzle
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)
  */

--- a/src/main/java/org/jpeek/Report.java
+++ b/src/main/java/org/jpeek/Report.java
@@ -57,6 +57,7 @@ import org.xembly.Xembler;
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocTagsCheck (500 lines)
+ * @todo #355:30min too short puzzle
  */
 final class Report {
     /**


### PR DESCRIPTION
Ressolving issue #355 
Travis lacks pdd checks.
The PR consists of ~3~ 4 commits:
* 23bdbd7 and 1e082eb : add badly worded puzzle -> we see here that travis accepts it
* 8c1337c : fix travis build script -> Travis is now failing
* cd51569 : remove the badly worded puzzle introduced in 23bdbd7 and 1e082eb, so everything is back to normal