### PR TITLE
#390 refactor and separate report generation from calculus

### DIFF
--- a/src/main/java/org/jpeek/App.java
+++ b/src/main/java/org/jpeek/App.java
@@ -70,16 +70,13 @@ import org.xembly.Xembler;
  *  and in `MetricsTest`).
  *  Once they are resolved add it to reports list.
  */
-@SuppressWarnings
-    (
-        {
-            "PMD.AvoidDuplicateLiterals",
-            "PMD.NPathComplexity",
-            "PMD.CyclomaticComplexity",
-            "PMD.StdCyclomaticComplexity",
-            "PMD.ModifiedCyclomaticComplexity"
-        }
-    )
+@SuppressWarnings({
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.NPathComplexity",
+    "PMD.CyclomaticComplexity",
+    "PMD.StdCyclomaticComplexity",
+    "PMD.ModifiedCyclomaticComplexity"
+})
 public final class App {
 
     /**
@@ -172,11 +169,12 @@ public final class App {
         final XSL chain = new XSLChain(layers);
         this.save(skeleton.toString(), "skeleton.xml");
         final Collection<Report> reports = new LinkedList<>();
+        final Calculus xsl = new XslCalculus();
         if (this.params.containsKey("LCOM")) {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "LCOM", this.params, 10.0d, -5.0d
+                    "LCOM", this.params, xsl, 10.0d, -5.0d
                 )
             );
         }
@@ -184,7 +182,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "CAMC", this.params
+                    "CAMC", this.params, xsl
                 )
             );
         }
@@ -192,7 +190,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "MMAC", this.params, 0.5d, 0.1d
+                    "MMAC", this.params, xsl, 0.5d, 0.1d
                 )
             );
         }
@@ -200,7 +198,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "LCOM5", this.params, 0.5d, -0.1d
+                    "LCOM5", this.params, xsl, 0.5d, -0.1d
                 )
             );
         }
@@ -208,7 +206,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "NHD"
+                    "NHD", xsl
                 )
             );
         }
@@ -216,7 +214,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "LCOM2", this.params
+                    "LCOM2", this.params, xsl
                 )
             );
         }
@@ -224,7 +222,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "LCOM3", this.params
+                    "LCOM3", this.params, xsl
                 )
             );
         }
@@ -232,7 +230,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "SCOM", this.params
+                    "SCOM", this.params, xsl
                 )
             );
         }
@@ -240,7 +238,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "OCC", this.params
+                    "OCC", this.params, xsl
                 )
             );
         }
@@ -248,7 +246,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "PCC"
+                    "PCC", xsl
                 )
             );
         }
@@ -256,7 +254,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "TCC"
+                    "TCC", xsl
                 )
             );
         }
@@ -264,7 +262,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "LCC"
+                    "LCC", xsl
                 )
             );
         }
@@ -272,7 +270,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "CCM"
+                    "CCM", xsl
                 )
             );
         }
@@ -280,7 +278,7 @@ public final class App {
             reports.add(
                 new XslReport(
                     chain.transform(skeleton),
-                    "MWE"
+                    "MWE", xsl
                 )
             );
         }

--- a/src/main/java/org/jpeek/Calculus.java
+++ b/src/main/java/org/jpeek/Calculus.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 /**
  * Metrics calculus interface.
- * @since 0.1
+ * @since 0.30.9
  * @todo #390:30min We have a separate interface to calculate XML metrics.
  *  We should continue to the goal defined in #296 where we should have a java
  *  implementation to calculate metrics. The motivation is to be able to make

--- a/src/main/java/org/jpeek/Calculus.java
+++ b/src/main/java/org/jpeek/Calculus.java
@@ -23,20 +23,29 @@
  */
 package org.jpeek;
 
+import com.jcabi.xml.XML;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.util.Map;
 
 /**
- * Report interface.
+ * Metrics calculus interface.
  * @since 0.1
+ * @todo #390:30min We have a separate interface to calculate XML metrics.
+ *  We should continue to the goal defined in #296 where we should have a java
+ *  implementation to calculate metrics. The motivation is to be able to make
+ *  calculations impossible or too difficult to implement in xsl. 
  */
-public interface Report {
+public interface Calculus {
 
     /**
-     * Save report.
-     * @param target Target dir
+     * Produces {@link XML} representing metrics values.
+     * @param metric Desired metric to calculate
+     * @param params Params
+     * @param skeleton Package input
+     * @return XML document giving metrics values for classes
      * @throws IOException If fails
      */
-    void save(Path target) throws IOException;
+    XML node(String metric, Map<String, Object> params, XML skeleton)
+        throws IOException;
 
 }

--- a/src/main/java/org/jpeek/Calculus.java
+++ b/src/main/java/org/jpeek/Calculus.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * @todo #390:30min We have a separate interface to calculate XML metrics.
  *  We should continue to the goal defined in #296 where we should have a java
  *  implementation to calculate metrics. The motivation is to be able to make
- *  calculations impossible or too difficult to implement in xsl. 
+ *  calculations impossible or too difficult to implement in xsl, like LCOM4.
  */
 public interface Calculus {
 

--- a/src/main/java/org/jpeek/XslCalculus.java
+++ b/src/main/java/org/jpeek/XslCalculus.java
@@ -23,20 +23,34 @@
  */
 package org.jpeek;
 
+import com.jcabi.xml.Sources;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.util.Map;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 
 /**
- * Report interface.
+ * Metrics xsl calculus. Use an xsl sheet to transform the input skeleton into
+ * the xml containing the calculation.
  * @since 0.1
  */
-public interface Report {
+public class XslCalculus implements Calculus {
 
-    /**
-     * Save report.
-     * @param target Target dir
-     * @throws IOException If fails
-     */
-    void save(Path target) throws IOException;
+    @Override
+    public XML node(String metric, Map<String, Object> params, XML skeleton)
+        throws IOException {
+        return new XSLDocument(
+            new TextOf(
+                new ResourceOf(
+                    new FormattedText("org/jpeek/metrics/%s.xsl", metric)
+                )
+            ).asString(),
+            Sources.DUMMY,
+            params
+        ).transform(skeleton);
+    }
 
 }

--- a/src/main/java/org/jpeek/XslCalculus.java
+++ b/src/main/java/org/jpeek/XslCalculus.java
@@ -37,11 +37,11 @@ import org.cactoos.text.TextOf;
  * the xml containing the calculation.
  * @since 0.1
  */
-public class XslCalculus implements Calculus {
+public final class XslCalculus implements Calculus {
 
     @Override
-    public XML node(String metric, Map<String, Object> params, XML skeleton)
-        throws IOException {
+    public XML node(final String metric, final Map<String, Object> params,
+        final XML skeleton) throws IOException {
         return new XSLDocument(
             new TextOf(
                 new ResourceOf(

--- a/src/main/java/org/jpeek/XslCalculus.java
+++ b/src/main/java/org/jpeek/XslCalculus.java
@@ -35,7 +35,7 @@ import org.cactoos.text.TextOf;
 /**
  * Metrics xsl calculus. Use an xsl sheet to transform the input skeleton into
  * the xml containing the calculation.
- * @since 0.1
+ * @since 0.30.9
  */
 public final class XslCalculus implements Calculus {
 

--- a/src/main/java/org/jpeek/XslReport.java
+++ b/src/main/java/org/jpeek/XslReport.java
@@ -143,10 +143,12 @@ final class XslReport implements Report {
      * @param calc Calculus
      * @param mean Mean
      * @param sigma Sigma
-     * @todo #390:30min this constructor now has too many arguments. We should find a way to refactor the constructor
-     *  or the class to have fewer parameters. We could start by analyzing the usage of this.params (args in this
-     *  constructor) and get rid of it if it is not used. Another idea could be to have a data class contaning
-     *  reporting params: name, args, mean, sigma.
+     * @todo #390:30min this constructor now has too many arguments. We should find a way
+     *  to refactor the constructor or the class to have fewer parameters.
+     *  We could start by analyzing the usage of this.params (args in this
+     *  constructor) and get rid of it if it is not used.
+     *  Another idea could be to have a data class contaning reporting params:
+     *  name, args, mean, sigma.
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     XslReport(final XML xml, final String name,

--- a/src/main/java/org/jpeek/XslReport.java
+++ b/src/main/java/org/jpeek/XslReport.java
@@ -143,11 +143,11 @@ final class XslReport implements Report {
      * @param calc Calculus
      * @param mean Mean
      * @param sigma Sigma
-     * @checkstyle ParameterNumberCheck (10 lines)
      * @todo #390:30min this constructor now has too many arguments. We should find a way to refactor the constructor
      *  or the class to have fewer parameters. We could start by analyzing the usage of this.params (args in this
      *  constructor) and get rid of it if it is not used. Another idea could be to have a data class contaning
      *  reporting params: name, args, mean, sigma.
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
     XslReport(final XML xml, final String name,
         final Map<String, Object> args, final Calculus calc,

--- a/src/main/java/org/jpeek/XslReport.java
+++ b/src/main/java/org/jpeek/XslReport.java
@@ -125,6 +125,7 @@ final class XslReport implements Report {
      * @param name Name of metric
      * @param args Params for XSL
      * @param calc Calculus
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     XslReport(final XML xml, final String name, final Map<String, Object> args,
         final Calculus calc) {

--- a/src/main/java/org/jpeek/XslReport.java
+++ b/src/main/java/org/jpeek/XslReport.java
@@ -144,6 +144,10 @@ final class XslReport implements Report {
      * @param mean Mean
      * @param sigma Sigma
      * @checkstyle ParameterNumberCheck (10 lines)
+     * @todo #390:30min this constructor now has too many arguments. We should find a way to refactor the constructor
+     *  or the class to have fewer parameters. We could start by analyzing the usage of this.params (args in this
+     *  constructor) and get rid of it if it is not used. Another idea could be to have a data class contaning
+     *  reporting params: name, args, mean, sigma.
      */
     XslReport(final XML xml, final String name,
         final Map<String, Object> args, final Calculus calc,

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -59,7 +59,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  *  Migrate this parametrized test to junit 5, so it won't import any classes from junit 4 anymore.
  * @checkstyle JavadocTagsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * 
  */
 @RunWith(Parameterized.class)
 @SuppressWarnings({

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -58,6 +58,8 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @todo #323:30min This test is fully written against JUnit 4 API.
  *  Migrate this parametrized test to junit 5, so it won't import any classes from junit 4 anymore.
  * @checkstyle JavadocTagsCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * 
  */
 @RunWith(Parameterized.class)
 @SuppressWarnings({

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -249,7 +249,7 @@ public final class MetricsTest {
         final Path output = Files.createTempDirectory("");
         new XslReport(
             new Skeleton(new FakeBase(this.target)).xml(),
-            this.metric
+            this.metric, new XslCalculus()
         ).save(output);
         final String xpath;
         if (Double.isNaN(this.value)) {

--- a/src/test/java/org/jpeek/XslCalculusTest.java
+++ b/src/test/java/org/jpeek/XslCalculusTest.java
@@ -33,7 +33,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link XslCalculus}.
- * @since 0.4
+ * @since 0.30.9
  */
 public final class XslCalculusTest {
 

--- a/src/test/java/org/jpeek/XslCalculusTest.java
+++ b/src/test/java/org/jpeek/XslCalculusTest.java
@@ -35,7 +35,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link XslCalculus}.
  * @since 0.4
  */
-
 public final class XslCalculusTest {
 
     @Test

--- a/src/test/java/org/jpeek/XslCalculusTest.java
+++ b/src/test/java/org/jpeek/XslCalculusTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jpeek;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.HashMap;
+import org.jpeek.skeleton.Skeleton;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+/**
+ * Test case for {@link XslCalculus}.
+ * @since 0.4
+ */
+
+public final class XslCalculusTest {
+
+    @Test
+    public void createsXmlCalculusWithXpaths() throws IOException {
+        final XML result = new XslCalculus().node(
+            "LCOM", new HashMap<>(0), new Skeleton(
+                new FakeBase(
+                    "NoMethods", "Bar", "OverloadMethods",
+                    "OnlyOneMethodWithParams", "WithoutAttributes"
+                )
+            ).xml()
+        );
+        new Assertion<>(
+            "Must create LCOM report",
+            result.toString(),
+            XhtmlMatchers.hasXPaths(
+                "/metric/app/package/class/vars",
+                "/metric/app/package/class/vars/var",
+                "/metric/app/package/class[@value]"
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void createsXmlCalculusWithEmptyProject() throws IOException {
+        final XML result = new XslCalculus().node(
+            "LCOM2", new HashMap<>(0), new Skeleton(new FakeBase()).xml()
+        );
+        new Assertion<>(
+            "Report for empty project created",
+            result.toString(),
+            XhtmlMatchers.hasXPaths(
+                "/metric[title='LCOM2']/app[@id]"
+            )
+        ).affirm();
+    }
+
+}

--- a/src/test/java/org/jpeek/XslReportTest.java
+++ b/src/test/java/org/jpeek/XslReportTest.java
@@ -48,7 +48,9 @@ public final class XslReportTest {
     @Test
     public void createsXmlReport() throws IOException {
         final Path output = Files.createTempDirectory("");
-        new XslReport(new Skeleton(new FakeBase()).xml(), "LCOM").save(output);
+        new XslReport(
+            new Skeleton(new FakeBase()).xml(), "LCOM", new XslCalculus()
+        ).save(output);
         new Assertion<>(
             "Must LCOM.xml file exists",
             Files.exists(output.resolve("LCOM.xml")),
@@ -71,7 +73,7 @@ public final class XslReportTest {
                     "OnlyOneMethodWithParams", "WithoutAttributes"
                 )
             ).xml(),
-            "LCOM"
+            "LCOM", new XslCalculus()
         ).save(output);
         new Assertion<>(
             "Must create LCOM report",
@@ -79,7 +81,6 @@ public final class XslReportTest {
                 new TextOf(output.resolve("LCOM.xml")).asString()
             ),
             XhtmlMatchers.hasXPaths(
-                "/metric/app/package/class/vars",
                 "/metric/statistics/mean",
                 "/metric/bars/bar[@x='0' and .='0' and @color='yellow']"
             )
@@ -89,7 +90,9 @@ public final class XslReportTest {
     @Test
     public void createsXmlReportWithEmptyProject() throws IOException {
         final Path output = Files.createTempDirectory("");
-        new XslReport(new Skeleton(new FakeBase()).xml(), "LCOM").save(output);
+        new XslReport(
+            new Skeleton(new FakeBase()).xml(), "LCOM", new XslCalculus()
+        ).save(output);
         new Assertion<>(
             "Report for empty project created",
             XhtmlMatchers.xhtml(
@@ -119,7 +122,7 @@ public final class XslReportTest {
                         .add("class").attr("id", "E").attr("value", "NaN").up()
                 ).xmlQuietly()
             ),
-            "LCOM"
+            "LCOM", new XslCalculus()
         ).save(output);
         new Assertion<>(
             "Must create full report",
@@ -141,7 +144,9 @@ public final class XslReportTest {
     @Test
     public void setsCorrectSchemaLocation() throws IOException {
         final Path output = Files.createTempDirectory("");
-        new XslReport(new Skeleton(new FakeBase()).xml(), "LCOM").save(output);
+        new XslReport(
+            new Skeleton(new FakeBase()).xml(), "LCOM", new XslCalculus()
+        ).save(output);
         new Assertion<>(
             "Must have correct schema location",
             XhtmlMatchers.xhtml(


### PR DESCRIPTION
Resolving #390.  The main idea is to separate report generation from metrics calculation. Finally, I chose to keep Xsl report as an xsl implementation for report generation. This is easier to continue to have statistics and post processing. But now, Xsl report is delegating metrics calculation to a new `Calculus` interface. `Calculus` interface implementation are supposed to produce an XML with the metrics calculation. Mainly, this PR:
* Refactors XslReport to separate metrics calculation concern, from post-processing and writing reports to disk concern
* Refactor tests accordingly
* Add a puzzle to have a Java calculus implementation for LCOM4