### PR TITLE
#195 Add a test case

### DIFF
--- a/src/main/resources/org/jpeek/metrics/TCC.xsl
+++ b/src/main/resources/org/jpeek/metrics/TCC.xsl
@@ -53,11 +53,6 @@ SOFTWARE.
     <xsl:variable name="NC" select="$methods_count * ($methods_count - 1) div 2"/>
     <xsl:variable name="directly-related-pairs">
       <xsl:for-each select="$methods">
-        <!--
-        @todo #120:30min TCC: need to come back and refactor the following after
-         #156 is fixed. The ops for fields must be properly filtered to ensure
-         that they belong to the enclosing class.
-        -->
         <xsl:variable name="i" select="position()"/>
         <xsl:variable name="left" select="."/>
         <xsl:variable name="left_attrs" select="$attrs[. = $left/ops/op/text()]"/>

--- a/src/test/java/org/jpeek/MetricsTest.java
+++ b/src/test/java/org/jpeek/MetricsTest.java
@@ -171,6 +171,7 @@ public final class MetricsTest {
             new Object[] {"Foo", "OCC", 0.5d},
             new Object[] {"Bar", "TCC", 0.0d},
             new Object[] {"Foo", "TCC", 1.0d},
+            new Object[] {"ClassSameAsAnotherPublicField", "TCC", 0.0d},
             new Object[] {"MethodsWithDiffParamTypes", "TCC", 0.2d},
             new Object[] {"OverloadMethods", "TCC", 1.0d},
             new Object[] {"TwoCommonAttributes", "TCC", 0.0d},

--- a/src/test/resources/org/jpeek/samples/ClassSameAsAnotherPublicField.java
+++ b/src/test/resources/org/jpeek/samples/ClassSameAsAnotherPublicField.java
@@ -1,0 +1,17 @@
+package org.jpeek.samples;
+
+public final class ClassSameAsAnotherPublicField {
+    private String NAME = "hey";
+
+    public void test() {
+        ClassWithPublicField.NAME = "test";
+    }
+    
+    public void foo() {
+        this.NAME = "test";
+    }
+}
+
+class ClassWithPublicField {
+    public static String NAME = "yoo";
+}


### PR DESCRIPTION
Resolving issue #195 
`$attrs` xslt variable on which we test and filter already takes attributes in skeleton that:
* are not static (so the problem in #156 can not happen)
* in skeleton ops/op text content already has the fully qualified name when it comes to other classes static fields

Added a test case to ensure this.