### PR TITLE
#213 fix TCC metric for no methods or no attributes

### DIFF
--- a/src/main/resources/org/jpeek/metrics/TCC.xsl
+++ b/src/main/resources/org/jpeek/metrics/TCC.xsl
@@ -72,7 +72,10 @@ SOFTWARE.
       <xsl:attribute name="value">
         <xsl:choose>
           <xsl:when test="$methods_count le 1">
-            <xsl:text>0</xsl:text>
+            <xsl:text>1</xsl:text>
+          </xsl:when>
+          <xsl:when test="count($attrs) lt 1">
+            <xsl:text>1</xsl:text>
           </xsl:when>
           <xsl:otherwise>
             <xsl:variable name="tcc" select="$NDC div $NC"/>

--- a/src/test/resources/org/jpeek/metricstest-params.csv
+++ b/src/test/resources/org/jpeek/metricstest-params.csv
@@ -88,7 +88,8 @@ ClassSameAsAnotherPublicField,TCC,0.0d
 MethodsWithDiffParamTypes,TCC,0.2d
 OverloadMethods,TCC,1.0d
 TwoCommonAttributes,TCC,0.0d
-WithoutAttributes,TCC,0.0d
+WithoutAttributes,TCC,1.0d
+NoMethods,TCC,1.0d
 IndirectlyRelatedPairs,TCC,0.6667
 Foo,TLCOM,1.0d
 MethodsWithDiffParamTypes,TLCOM,15.0d


### PR DESCRIPTION
Resolving issue #213 
* Force TCC value to 1 if no attributes or if it has less or equal to 1 method.
* Fix WithoutAttributes test value to 1
* Add a test case for no methods.
