### PR TITLE
#313 bump jcabi parent version to 0.49.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.2</version>
+    <version>0.49.9</version>
   </parent>
   <groupId>org.jpeek</groupId>
   <artifactId>jpeek</artifactId>
@@ -81,6 +81,20 @@ SOFTWARE.
       <url>https://github.com/yegor256/jpeek</url>
     </site>
   </distributionManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.cactoos</groupId>
@@ -213,19 +227,17 @@ SOFTWARE.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.5.2</version>
+      <version>${junit-platform.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -268,8 +280,6 @@ SOFTWARE.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>

--- a/src/main/java/org/jpeek/web/Dynamo.java
+++ b/src/main/java/org/jpeek/web/Dynamo.java
@@ -71,7 +71,7 @@ final class Dynamo implements Region {
     private static Region live() throws IOException {
         final Properties props = Dynamo.pros();
         final Region reg;
-        if (Dynamo.class.getResource("/org/junit/Test.class") == null) {
+        if (Dynamo.class.getResource("/org/junit/jupiter/api/Test.class") == null) {
             reg = new Region.Simple(
                 new Credentials.Simple(
                     props.getProperty("org.jpeek.dynamo.key"),


### PR DESCRIPTION
This is for #313.

According to jcabi changelog, this was fixed since 0.49.2 (most certainly with 0.49.5 but changelog is not extremely clear).

Since
- 0.49.2 was released before #313 was opened
- 0.49.9 was released after #313 was opened

I believe this should be alright to answer the ticket submitter request for using latest snapshot at the time.
