### PR TITLE
For #465: split dokku repository reset

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -31,7 +31,7 @@ release:
     git commit -am "${tag}"
     mvn clean deploy -Pjpeek -Psonar -Pqulice -Psonatype --errors --settings ../settings.xml
     cp ../settings.xml settings.xml
-    mvn clean package -Pqulice -Pjpeek --errors --batch-mode
+    mvn clean package -Pqulice --errors --batch-mode
     rm -rf ~/.ssh
     mkdir ~/.ssh
     mv ../id_rsa ../id_rsa.pub ~/.ssh
@@ -39,5 +39,6 @@ release:
     echo -e "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
     git remote add dokku dokku@dokku.jpeek.org:jpeek
     git add settings.xml
-    git commit -m 'settings.xml' && git push -f dokku $(git symbolic-ref --short HEAD):master && git reset HEAD~1
+    git commit -m 'settings.xml' && git push -f dokku $(git symbolic-ref --short HEAD):master
+    git reset HEAD~1
     curl -f --connect-timeout 15 --retry 5 --insecure --retry-delay 30 https://i.jpeek.org > /dev/null


### PR DESCRIPTION
Last lines of `434aa056` rultor release execution are failing due to a `settings.xml` file left on the repository, because the reset command is not being executed when there is a failure to push the repository to dokku.
```
+ rm -rf /home/r/.ssh
+ mkdir /home/r/.ssh
+ mv ../id_rsa ../id_rsa.pub /home/r/.ssh
+ chmod 600 /home/r/.ssh/id_rsa /home/r/.ssh/id_rsa.pub
+ echo -e 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null'
+ git remote add dokku dokku@dokku.jpeek.org:jpeek
+ git add settings.xml
+ git commit -m settings.xml
[__rultor a153e96] settings.xml
 1 file changed, 33 insertions(+)
 create mode 100644 settings.xml
++ git symbolic-ref --short HEAD
+ git push -f dokku __rultor:master
Warning: Permanently added 'dokku.jpeek.org,178.238.236.225' (ECDSA) to the list of known hosts.
Enumerating objects: 10077, done.
Counting objects: 100% (10077/10077), done.
Delta compression using up to 12 threads
Compressing objects: 100% (3266/3266), done.
Writing objects: 100% (10077/10077),712.31MMiB||113.07MMiB/s, done.
Total 10077 (delta 4817), reused 10068 (delta 4812)
remote: Resolving deltas: 100% (4817/4817),Kdone.K
remote: Reinitializing monit daemonK
remote: 1G-----> Cleaning up...K
remote: 1G-----> Building jpeek from herokuish...K
remote: 1GReinitializing monit daemonK
remote: 1G-----> Adding BUILD_ENV to build environment...K
remote: 1G1G       1G-----> Java app detectedK
remote: 1G1G-----> Installing JDK 1.8... doneK
remote: 1G1G-----> Installing Maven 3.6.2... doneK
remote: 1G1G-----> Executing MavenK
remote: 1G1G       $ mvn -DskipTests -Dinvoker.skip clean dependency:list installK
remote: Picked up JAVA_TOOL_OPTIONS: -Xmx1g -Xss512k -XX:CICompilerCount=2 -Dfile.encoding=UTF-8K
remote: 1G1G---------------------------------------------------K
remote: 1G1G       constituent[0]: file:/cache/.maven/conf/logging/K
remote: 1G1G       constituent[1]: file:/cache/.maven/lib/maven-resolver-spi-1.4.1.jarK
remote: 1G1G       constituent[2]:#K
remote: 1G1G       # There is insufficient memory for the Java Runtime Environment to continue.K
remote: 1G1G       # Native memory allocation (malloc) failed to allocate 32744 bytes for ChunkPool::allocateK
remote: 1G1G       file:# An error report file with more information is saved as:K
remote: 1G1G       # /tmp/build/hs_err_pid344.logK
remote: 1G1G       /cache/.maven/lib/commons-lang3-3.8.1.jarK
remote: 1G1G       constituent[3]: file:/cache/.maven/lib/org.eclipse.sisu.inject-0.3.3.jarK
remote: 1G1G       constituent[4]: file:/cache/.maven/lib/maven-builder-support-3.6.2.jarK
remote: 1G1G       constituent[5]: file:/cache/.maven/lib/javax.inject-1.jarK
remote: 1G1G       constituent[6]: file:/cache/.maven/lib/jsr250-api-1.0.jarK
remote: 1G1G       constituent[7]: file:/cache/.maven/lib/maven-embedder-3.6.2.jarK
remote: 1G1G       constituent[8]: file:/cache/.maven/lib/plexus-utils-3.2.1.jarK
remote: 1G1G       constituent[9]: file:/cache/.maven/lib/maven-shared-utils-3.2.1.jarK
remote: 1G1G       constituent[10]: file:/cache/.maven/lib/commons-cli-1.4.jarK
remote: 1G1G       constituent[11]: file:/cache/.maven/lib/org.eclipse.sisu.plexus-0.3.3.jarK
remote: 1G1G       constituent[12]: file:/cache/.maven/lib/wagon-http-3.3.3-shaded.jarK
remote: 1G1G       constituent[13]: file:/cache/.maven/lib/maven-settings-3.6.2.jarK
remote: 1G1G       constituent[14]: file:/cache/.maven/lib/jcl-over-slf4j-1.7.25.jarK
remote: 1G1G       constituent[15]: file:/cache/.maven/lib/maven-resolver-util-1.4.1.jarK
remote: 1G1G       constituent[16]: file:/cache/.maven/lib/wagon-file-3.3.3.jarK
remote: 1G1G       constituent[17]: file:/cache/.maven/lib/plexus-component-annotations-2.0.0.jarK
remote: 1G1G       constituent[18]: file:/cache/.maven/lib/slf4j-api-1.7.25.jarK
remote: 1G1G       constituent[19]: file:/cache/.maven/lib/maven-slf4j-provider-3.6.2.jarK
remote: 1G1G       constituent[20]: file:/cache/.maven/lib/maven-artifact-3.6.2.jarK
remote: 1G1G       constituent[21]: file:/cache/.maven/lib/maven-resolver-api-1.4.1.jarK
remote: 1G1G       constituent[22]: file:/cache/.maven/lib/plexus-cipher-1.7.jarK
remote: 1G1G       constituent[23]: file:/cache/.maven/lib/jansi-1.17.1.jarK
remote: 1G1G       constituent[24]: file:/cache/.maven/lib/maven-resolver-impl-1.4.1.jarK
remote: 1G1G       constituent[25]: file:/cache/.maven/lib/guava-25.1-android.jarK
remote: 1G1G       constituent[26]: file:/cache/.maven/lib/maven-core-3.6.2.jarK
remote: 1G1G       constituent[27]: file:/cache/.maven/lib/plexus-sec-dispatcher-1.4.jarK
remote: 1G1G       constituent[28]: file:/cache/.maven/lib/maven-resolver-provider-3.6.2.jarK
remote: 1G1G       constituent[29]: file:/cache/.maven/lib/maven-repository-metadata-3.6.2.jarK
remote: 1G1G       constituent[30]: file:/cache/.maven/lib/maven-resolver-#K
remote: 1G1G       # Compiler replay data is saved as:K
remote: 1G1G       # /tmp/build/replay_pid344.logK
remote: 1G1G       transporK
remote: 1G1G       !     ERROR: Failed to build app with MavenK
remote: 1G1G       We're sorry this build is failing! If you can't find the issue in application code,K
remote: 1G1G       please submit a ticket so we can help: https://help.heroku.com/K
remote: 1G1G       K
To dokku.jpeek.org:jpeek
 31m! [remote rejected]m __rultor -> master (pre-receive hook declined)
31merror: failed to push some refs to 'dokku@dokku.jpeek.org:jpeek'
m+ curl -f --connect-timeout 15 --retry 5 --insecure --retry-delay 30 https://i.jpeek.org
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14661    0 14661    0     0  16736      0 --:--:-- --:--:-- --:--:-- 16717
+ mv /home/r/repo .
++ whoami
+ chown -R root repo
+ '[' -n '' ']'
++ whoami
+ sudo chown -R rultor repo
+ cd repo
+ for f in '"${sensitive[@]}"'
+ '[' -e settings.xml ']'
+ echo 'Sensitive file settings.xml is present, can'\''t release'
Sensitive file settings.xml is present, can't release
+ exit - 1
./run.sh: line 170: exit: -: numeric argument required
container a7aa8afc19d1b6718df5f3ade7ea650f8aecf1ffa48b7b3b5c784bc111401966 is dead
Sun Apr 26 06:51:15 CEST 2020
```
This fix the reset of the current repository even if we fail to publish to dokku server