### PR TITLE
#470 - Fixed LORM XSL.

### DIFF
--- a/src/main/resources/org/jpeek/metrics/LORM.xsl
+++ b/src/main/resources/org/jpeek/metrics/LORM.xsl
@@ -64,8 +64,8 @@ SOFTWARE.
     <xsl:variable name="relations">
       <xsl:for-each select="$methods">
         <xsl:variable name="from" select="@name"/>
-        <xsl:for-each select="ops/op[@code='call'][starts-with(text(), $prefix)]">
-          <xsl:variable name="to" select="substring-after(text(), $prefix)"/>
+        <xsl:for-each select="ops/op[@code='call'][starts-with(name, $prefix)]">
+          <xsl:variable name="to" select="substring-after(name, $prefix)"/>
           <link from="{$from}" to="{$to}"/>
         </xsl:for-each>
       </xsl:for-each>

--- a/src/test/java/org/jpeek/metrics/LormTest.java
+++ b/src/test/java/org/jpeek/metrics/LormTest.java
@@ -25,7 +25,6 @@
 package org.jpeek.metrics;
 
 import org.cactoos.list.ListOf;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,12 +34,10 @@ import org.junit.jupiter.api.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class LormTest {
+final class LormTest {
+
     @Test
-    @Disabled
-    // @todo #437:30min This test was disabled after skeleton structure has changed as in #437.
-    //  Fix LORM.xsl to make it comply with the new structure and then reenable this test again.
-    public void calculatesVariables() throws Exception {
+    void calculatesVariables() throws Exception {
         final MetricBase.Report report = new MetricBase(
             "org/jpeek/metrics/LORM.xsl"
         ).transform(


### PR DESCRIPTION
PR for #470 

Fixed the XSL to work with new skeleton structure and re-enabled the test.