### PR TITLE
#449 - Begin Java CCM.

### DIFF
--- a/src/main/java/org/jpeek/calculus/Calculus.java
+++ b/src/main/java/org/jpeek/calculus/Calculus.java
@@ -36,6 +36,18 @@ import java.util.Map;
  *  only we should also remove LCOM4.xsl part that is doing the calculus and let the xsl here just
  *  to build the structure of the xml result. This part is especially the one calculating
  *  "xsl:variable name='E'" L73->L89, and the one doing the division L97 -> L99
+ * @todo #449:30min The `node` method in this interface was designed with only
+ *  XSL implementation in mind - it uses the `metric` parameter to select the
+ *  XSL file and uses that file to transform the `skeleton`. This makes Java
+ *  based implementations a little awkward because the `metric` parameter
+ *  becomes redundant: there is a Java implementation for each metric, and these
+ *  implementations already know which metric they are for. The question becomes
+ *  - how to select correct java implementation for a given metric and integrate
+ *  it seamlessly with XSL calculus in `XslReport`. One option could be removing
+ *  the `metric` parameter from the method and injecting a Calculus for a
+ *  concrete metric in `XslReport` directly. Another could be implementing
+ *  Chain Of Responsibility pattern. Decide on the best way to integrate Java
+ *  based Calculus with XSL based Calculus in `XslReport` and implement it.
  */
 public interface Calculus {
 

--- a/src/main/java/org/jpeek/calculus/java/Ccm.java
+++ b/src/main/java/org/jpeek/calculus/java/Ccm.java
@@ -88,7 +88,8 @@ public final class Ccm implements Calculus {
      * @todo #449:30min Implement NCC calculation with `XmlGraph` and use this
      *  class to fix CCM metric (see issue #449). To do this, this class, once
      *  it works correctly, should be integrated with XSL based calculuses in
-     *  `XslReport` (see `todo #449` in Calculus). Also, decide whether the
+     *  `XslReport` (see `todo #449` in Calculus). Write a test to make sure
+     *  the metric is calculated correctly. Also, decide whether the
      *  whole CCM metric should be implemented in Java, or only the NCC part.
      *  Update this `todo` accordingly.
      */

--- a/src/main/java/org/jpeek/calculus/java/Ccm.java
+++ b/src/main/java/org/jpeek/calculus/java/Ccm.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jpeek.calculus.java;
+
+import com.jcabi.xml.Sources;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XSLDocument;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.Joined;
+import org.cactoos.text.TextOf;
+import org.jpeek.calculus.Calculus;
+
+/**
+ * CCM metric Java calculus.
+ * @since 0.30.25
+ */
+public final class Ccm implements Calculus {
+
+    @Override
+    public XML node(final String metric, final Map<String, Object> params,
+        final XML skeleton) throws IOException {
+        final XML result = new XSLDocument(
+            new TextOf(
+                new ResourceOf("org/jpeek/metrics/CCM.xsl")
+            ).asString(),
+            Sources.DUMMY,
+            params
+        ).transform(skeleton);
+        final List<XML> packages = result.nodes("//package");
+        for (final XML elt : packages) {
+            final String pack = elt.xpath("/@id").get(0);
+            final List<XML> classes = elt.nodes("//class");
+            for (final XML clazz : classes) {
+                Ccm.updateNcc(skeleton, pack, clazz);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Updates the xml node of the class with proper NCC value.
+     * @param skeleton XML Skeleton
+     * @param pack Package name
+     * @param clazz Class node in the resulting xml
+     * @todo #449:30min Implement NCC calculation with `XmlGraph` and use this
+     *  class to fix CCM metric (see issue #449). To do this, this class, once
+     *  it works correctly, should be integrated with XSL based calculuses in
+     *  `XslReport` (see `todo #449` in Calculus). Also, decide whether the
+     *  whole NCC metric should be implemented in Java, or only the NCC part.
+     *  Update this `todo` accordingly.
+     */
+    private static void updateNcc(
+        final XML skeleton, final String pack, final XML clazz
+    ) {
+        throw new UnsupportedOperationException(
+            new Joined(
+                "",
+                skeleton.toString(),
+                pack,
+                clazz.toString()
+            ).toString()
+        );
+    }
+}

--- a/src/main/java/org/jpeek/calculus/java/Ccm.java
+++ b/src/main/java/org/jpeek/calculus/java/Ccm.java
@@ -28,7 +28,7 @@ import com.jcabi.xml.XSLDocument;
 import java.util.List;
 import java.util.Map;
 import org.cactoos.io.ResourceOf;
-import org.cactoos.scalar.Unchecked;
+import org.cactoos.io.UncheckedInput;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
 import org.jpeek.calculus.Calculus;
@@ -53,11 +53,11 @@ public final class Ccm implements Calculus {
             );
         }
         return Ccm.withFixedNcc(
-            new Unchecked<>(
-                () -> new XSLDocument(
-                    new ResourceOf("org/jpeek/metrics/CCM.xsl").stream()
-                ).transform(skeleton)
-            ).value(),
+            new XSLDocument(
+                new UncheckedInput(
+                    new ResourceOf("org/jpeek/metrics/CCM.xsl")
+                ).stream()
+            ).transform(skeleton),
             skeleton
         );
     }


### PR DESCRIPTION
#449 

To calculate NCC correctly, we will use Java `Graph` instead of XSL. This PR introduces Java based CCM Calculus and adds `todo`s for further work.